### PR TITLE
no jira: allow non-string messages to be logged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 ## [0.6.0] - Unreleased
 ### Added
 - The ability to redact sensitive data from log entries by registering the sensitive strings ahead of time with the logger
+- `ContextualLogger#normalize_message` as a general logging helper method to normalize any message to string format.
 
 ### Changed
 - Restored ::Logger's ability to log non-string messages like `nil` or `false`, in case there's a gem
   we use someday that depends on that.
+
+- JSON logging now logs all messages as strings, by calling `normalize_message`, above.
+  Previously, messages were converted by `.to_json`, so `nil` was logged as JSON `null`; now it is logged as the string `"nil"`.
+  Similarly, `false` was logged as JSON `false`; now it is logged as the string `"false"`.
 
 ## [0.5.1] - 2020-03-10
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 ### Added
 - The ability to redact sensitive data from log entries by registering the sensitive strings ahead of time with the logger
 
+### Changed
+- Restored ::Logger's ability to log non-string messages like `nil` or `false`, in case there's a gem
+  we use someday that depends on that.
+
 ## [0.5.1] - 2020-03-10
 ### Changed
 - Fixed Rails Server logging to STDOUT: Refactored debug, info, error... etc methods to call the base class `add(severity, message, progrname)` method since

--- a/lib/contextual_logger.rb
+++ b/lib/contextual_logger.rb
@@ -62,27 +62,27 @@ module ContextualLogger
     end
 
     def debug(message = nil, context = {})
-      add(Logger::Severity::DEBUG, message || yield, **context)
+      add(Logger::Severity::DEBUG, message.nil? && block_given? ? yield : message, **context)
     end
 
     def info(message = nil, context = {})
-      add(Logger::Severity::INFO, message || yield, **context)
+      add(Logger::Severity::INFO, message.nil? && block_given? ? yield : message, **context)
     end
 
     def warn(message = nil, context = {})
-      add(Logger::Severity::WARN, message || yield, **context)
+      add(Logger::Severity::WARN, message.nil? && block_given? ? yield : message, **context)
     end
 
     def error(message = nil, context = {})
-      add(Logger::Severity::ERROR, message || yield, **context)
+      add(Logger::Severity::ERROR, message.nil? && block_given? ? yield : message, **context)
     end
 
     def fatal(message = nil, context = {})
-      add(Logger::Severity::FATAL, message || yield, **context)
+      add(Logger::Severity::FATAL, message.nil? && block_given? ? yield : message, **context)
     end
 
     def unknown(message = nil, context = {})
-      add(Logger::Severity::UNKNOWN, message || yield, **context)
+      add(Logger::Severity::UNKNOWN, message.nil? && block_given? ? yield : message, **context)
     end
 
     def log_level_enabled?(severity)

--- a/lib/contextual_logger.rb
+++ b/lib/contextual_logger.rb
@@ -33,6 +33,15 @@ module ContextualLogger
         end
       end
     end
+
+    def normalize_message(message)
+      case message
+      when String
+        message
+      else
+        message.inspect
+      end
+    end
   end
 
   module LoggerMixin
@@ -134,7 +143,7 @@ module ContextualLogger
     def message_hash_with_context(severity, timestamp, progname, message, context:)
       message_hash =
         {
-          message:   message,
+          message:   ContextualLogger.normalize_message(message),
           severity:  severity,
           timestamp: timestamp
         }

--- a/spec/lib/contextual_logger_spec.rb
+++ b/spec/lib/contextual_logger_spec.rb
@@ -123,12 +123,12 @@ describe ContextualLogger do
         log_message_at_every_level(logger, nil)
 
         expect(log_stream.string.gsub(/"timestamp":"[^"]+"/, '<time>')).to eq(<<~EOS)
-          {"message":null,"severity":"DEBUG",<time>}
-          {"message":null,"severity":"INFO",<time>}
-          {"message":null,"severity":"WARN",<time>}
-          {"message":null,"severity":"ERROR",<time>}
-          {"message":null,"severity":"FATAL",<time>}
-          {"message":null,"severity":"ANY",<time>}
+          {"message":"nil","severity":"DEBUG",<time>}
+          {"message":"nil","severity":"INFO",<time>}
+          {"message":"nil","severity":"WARN",<time>}
+          {"message":"nil","severity":"ERROR",<time>}
+          {"message":"nil","severity":"FATAL",<time>}
+          {"message":"nil","severity":"ANY",<time>}
         EOS
       end
     end
@@ -139,12 +139,12 @@ describe ContextualLogger do
         log_message_at_every_level(logger, false)
 
         expect(log_stream.string.gsub(/"timestamp":"[^"]+"/, '"timestamp":"<time>"')).to eq(<<~EOS)
-          {"message":false,"severity":"DEBUG","timestamp":"<time>"}
-          {"message":false,"severity":"INFO","timestamp":"<time>"}
-          {"message":false,"severity":"WARN","timestamp":"<time>"}
-          {"message":false,"severity":"ERROR","timestamp":"<time>"}
-          {"message":false,"severity":"FATAL","timestamp":"<time>"}
-          {"message":false,"severity":"ANY","timestamp":"<time>"}
+          {"message":"false","severity":"DEBUG","timestamp":"<time>"}
+          {"message":"false","severity":"INFO","timestamp":"<time>"}
+          {"message":"false","severity":"WARN","timestamp":"<time>"}
+          {"message":"false","severity":"ERROR","timestamp":"<time>"}
+          {"message":"false","severity":"FATAL","timestamp":"<time>"}
+          {"message":"false","severity":"ANY","timestamp":"<time>"}
         EOS
       end
     end
@@ -408,6 +408,44 @@ describe ContextualLogger do
         LOG_LEVEL_STRINGS_TO_CONSTANTS.each do |uppercase_string_level, constant_level|
           lowercase_symbol_level = uppercase_string_level.downcase.to_sym
           expect(ContextualLogger.normalize_log_level(lowercase_symbol_level)).to eq(constant_level)
+        end
+      end
+    end
+
+    describe "normalize_message" do
+      class CustomInspect
+        def inspect
+          "<custom>"
+        end
+      end
+
+      describe 'with nil' do
+        it "returns 'nil'" do
+          expect(ContextualLogger.normalize_message(nil)).to eq("nil")
+        end
+      end
+
+      describe 'with false' do
+        it "returns 'false'" do
+          expect(ContextualLogger.normalize_message(false)).to eq("false")
+        end
+      end
+
+      describe 'with a symbol' do
+        it "returns :symbol" do
+          expect(ContextualLogger.normalize_message(:symbol)).to eq(":symbol")
+        end
+      end
+
+      describe 'with a custom #inspect' do
+        it "returns .inspect" do
+          expect(ContextualLogger.normalize_message(CustomInspect.new)).to eq("<custom>")
+        end
+      end
+
+      describe 'with an Exception' do
+        it "returns .inspect (skipping the backtrace)" do
+          expect(ContextualLogger.normalize_message(ArgumentError.new("err"))).to eq("#<ArgumentError: err>")
         end
       end
     end

--- a/spec/lib/contextual_logger_spec.rb
+++ b/spec/lib/contextual_logger_spec.rb
@@ -21,70 +21,71 @@ describe ContextualLogger do
 
   it { is_expected.to respond_to(:with_context) }
 
-  context 'log_level' do
+  context 'with logger writing to log_stream' do
     let(:log_stream) { StringIO.new }
-    let(:default_logger) { ContextualLogger.new(Logger.new(log_stream)) }
     let(:log_level) { Logger::Severity::DEBUG }
     let(:logger) { ContextualLogger.new(Logger.new(log_stream, level: log_level)) }
 
-    context 'at default level' do
-      it 'respects log level debug' do
-        log_at_every_level(default_logger)
-        expect(log_message_levels).to eq(["debug", "info", "warn", "error", "fatal", "unknown"])
+    describe 'log level' do
+      context 'at default level' do
+        it 'respects log level debug' do
+          log_at_every_level(logger)
+          expect(log_message_levels).to eq(["debug", "info", "warn", "error", "fatal", "unknown"])
+        end
       end
-    end
 
-    context 'at level debug' do
-      let(:log_level) { Logger::Severity::DEBUG }
+      context 'at level debug' do
+        let(:log_level) { Logger::Severity::DEBUG }
 
-      it 'respects log level' do
-        log_at_every_level(logger)
-        expect(log_message_levels).to eq(["debug", "info", "warn", "error", "fatal", "unknown"])
+        it 'respects log level' do
+          log_at_every_level(logger)
+          expect(log_message_levels).to eq(["debug", "info", "warn", "error", "fatal", "unknown"])
+        end
       end
-    end
 
-    context 'at level info' do
-      let(:log_level) { Logger::Severity::INFO }
+      context 'at level info' do
+        let(:log_level) { Logger::Severity::INFO }
 
-      it 'respects log level' do
-        log_at_every_level(logger)
-        expect(log_message_levels).to eq(["info", "warn", "error", "fatal", "unknown"])
+        it 'respects log level' do
+          log_at_every_level(logger)
+          expect(log_message_levels).to eq(["info", "warn", "error", "fatal", "unknown"])
+        end
       end
-    end
 
-    context 'at level warn' do
-      let(:log_level) { Logger::Severity::WARN }
+      context 'at level warn' do
+        let(:log_level) { Logger::Severity::WARN }
 
-      it 'respects log level' do
-        log_at_every_level(logger)
-        expect(log_message_levels).to eq(["warn", "error", "fatal", "unknown"])
+        it 'respects log level' do
+          log_at_every_level(logger)
+          expect(log_message_levels).to eq(["warn", "error", "fatal", "unknown"])
+        end
       end
-    end
 
-    context 'at level error' do
-      let(:log_level) { Logger::Severity::ERROR }
+      context 'at level error' do
+        let(:log_level) { Logger::Severity::ERROR }
 
-      it 'respects log level' do
-        log_at_every_level(logger)
-        expect(log_message_levels).to eq(["error", "fatal", "unknown"])
+        it 'respects log level' do
+          log_at_every_level(logger)
+          expect(log_message_levels).to eq(["error", "fatal", "unknown"])
+        end
       end
-    end
 
-    context 'at level fatal' do
-      let(:log_level) { Logger::Severity::FATAL }
+      context 'at level fatal' do
+        let(:log_level) { Logger::Severity::FATAL }
 
-      it 'respects log level' do
-        log_at_every_level(logger)
-        expect(log_message_levels).to eq(["fatal", "unknown"])
+        it 'respects log level' do
+          log_at_every_level(logger)
+          expect(log_message_levels).to eq(["fatal", "unknown"])
+        end
       end
-    end
 
-    context 'at level unknown' do
-      let(:log_level) { Logger::Severity::UNKNOWN }
+      context 'at level unknown' do
+        let(:log_level) { Logger::Severity::UNKNOWN }
 
-      it 'respects log level' do
-        log_at_every_level(logger)
-        expect(log_message_levels).to eq(["unknown"])
+        it 'respects log level' do
+          log_at_every_level(logger)
+          expect(log_message_levels).to eq(["unknown"])
+        end
       end
     end
 
@@ -113,6 +114,38 @@ describe ContextualLogger do
         expect(log_message_levels).to eq(["error"])
         # note: context lands in `progname` arg
         expect(console_log_stream.string.gsub(/\[[^]]+\]/, '[]')).to eq("E, [] ERROR -- {:service=>\"test_service\"}: error message\n")
+      end
+    end
+
+    describe 'with nil message' do
+      it "logs null" do
+        logger.level = Logger::Severity::DEBUG
+        log_message_at_every_level(logger, nil)
+
+        expect(log_stream.string.gsub(/"timestamp":"[^"]+"/, '<time>')).to eq(<<~EOS)
+          {"message":null,"severity":"DEBUG",<time>}
+          {"message":null,"severity":"INFO",<time>}
+          {"message":null,"severity":"WARN",<time>}
+          {"message":null,"severity":"ERROR",<time>}
+          {"message":null,"severity":"FATAL",<time>}
+          {"message":null,"severity":"ANY",<time>}
+        EOS
+      end
+    end
+
+    describe 'with false message' do
+      it "logs false" do
+        logger.level = Logger::Severity::DEBUG
+        log_message_at_every_level(logger, false)
+
+        expect(log_stream.string.gsub(/"timestamp":"[^"]+"/, '"timestamp":"<time>"')).to eq(<<~EOS)
+          {"message":false,"severity":"DEBUG","timestamp":"<time>"}
+          {"message":false,"severity":"INFO","timestamp":"<time>"}
+          {"message":false,"severity":"WARN","timestamp":"<time>"}
+          {"message":false,"severity":"ERROR","timestamp":"<time>"}
+          {"message":false,"severity":"FATAL","timestamp":"<time>"}
+          {"message":false,"severity":"ANY","timestamp":"<time>"}
+        EOS
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,15 @@ module Helpers
     logger.unknown("unknown message", context)
   end
 
+  def log_message_at_every_level(logger, message, context = {})
+    logger.debug(message, context)
+    logger.info(message, context)
+    logger.warn(message, context)
+    logger.error(message, context)
+    logger.fatal(message, context)
+    logger.unknown(message, context)
+  end
+
   def log_message_levels
     log_stream.string.split("\n").map { |log_line| log_line[/([a-z]+) message/, 1] }
   end


### PR DESCRIPTION
### Summary of Changes
- Restored ability to log non-string messages. See CHANGELOG for more detail.
