### PR TITLE
Add sensitive data redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # CHANGELOG for `contextual_logger`
 
 Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
-
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.1] - 2020-03-10 [diff](https://github.com/Invoca/contextual_logger/compare/v0.5.0...v0.5.1)
+## [0.6.0] - Unreleased
+### Added
+- The ability to redact sensitive data from log entries by registering the sensitive strings ahead of time with the logger
 
+## [0.5.1] - 2020-03-10
 ### Changed
-
 - Fixed Rails Server logging to STDOUT: Refactored debug, info, error... etc methods to call the base class `add(severity, message, progrname)` method since
   `ActiveSupport::Logger.broadcast` reimplements that to broadcast to multiple logger instances, such as
   `Rails::Server` logging to `STDOUT` + `development.log`.
@@ -16,8 +17,11 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
   `**context` argument, if present. If that argument is not present (such as with `broadcast`), Ruby will instead
   match the `**context` up to the `progname` argument.
 
-## [0.5.0] - 2020-03-06 [diff](https://github.com/Invoca/contextual_logger/compare/v0.4.0...v0.5.0)
-
+## [0.5.0] - 2020-03-06
 ### Added
  - Extracted `ContextualLogger.normalize_log_level` into a public class method so we can call it elsewhere where we allow log_level to be
    configured to text values like 'debug'.
+
+[0.6.0]: https://github.com/Invoca/contextual_logger/compare/v0.5.1...v0.6.0
+[0.5.1]: https://github.com/Invoca/contextual_logger/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/Invoca/contextual_logger/compare/v0.4.0...v0.5.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    contextual_logger (0.5.1)
+    contextual_logger (0.6.0)
       activesupport
       json
 

--- a/README.md
+++ b/README.md
@@ -50,11 +50,12 @@ If you'd like to set a global context for your process, you can do the following
 contextual_logger.global_context = { service_name: 'test_service' }
 ```
 
-#### Redaction
+### Redaction
+#### Registering a Secret
 In order to register sensitive strings to the logger for redaction to occur, do the following:
 ```ruby
 password = "ffbba9b905c0a549b48f48894ad7aa9b7bd7c06c"
-contextual_logger.redactor.match(password)
+contextual_logger.register_secret(password)
 
 contextual_logger.info("Request sent with body { 'username': 'test_user', 'password': 'ffbba9b905c0a549b48f48894ad7aa9b7bd7c06c' } }")
 ```

--- a/README.md
+++ b/README.md
@@ -53,9 +53,15 @@ contextual_logger.global_context = { service_name: 'test_service' }
 #### Redaction
 In order to register sensitive strings to the logger for redaction to occur, do the following:
 ```ruby
-contextual_logger.redactor.match('some_sensitive_data')
+password = "ffbba9b905c0a549b48f48894ad7aa9b7bd7c06c"
+contextual_logger.redactor.match(password)
+
+contextual_logger.info("Request sent with body { 'username': 'test_user', 'password': 'ffbba9b905c0a549b48f48894ad7aa9b7bd7c06c' } }")
 ```
-This string will then be replaced with `<redacted>` whenever the logger is about to log to the file.
+The above will produce the resulting log line:
+```
+03/10/20 12:22:05.769 INFO Request sent with body { 'username': 'test_user', 'password': '<redacted>' }
+```
 
 ### Overrides
 #### ActiveSupport::TaggedLogging

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ If you'd like to set a global context for your process, you can do the following
 contextual_logger.global_context = { service_name: 'test_service' }
 ```
 
+#### Redaction
+In order to register sensitive strings to the logger for redaction to occur, do the following:
+```ruby
+contextual_logger.redactor.match('some_sensitive_data')
+```
+This string will then be replaced with `<redacted>` whenever the logger is about to log to the file.
+
 ### Overrides
 #### ActiveSupport::TaggedLogging
 ActiveSupport's TaggedLogging extension adds the ability for tags to be prepended onto logs in an easy to use way.  This is a very

--- a/contextual_logger.gemspec
+++ b/contextual_logger.gemspec
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "contextual_logger/version"
+
 Gem::Specification.new do |spec|
   spec.name        = 'contextual_logger'
-  spec.version     = '0.5.1'
+  spec.version     = ContextualLogger::VERSION
   spec.license     = 'MIT'
   spec.summary     = 'Add context to your logger'
   spec.description = 'A way to add context to the logs you have'

--- a/lib/contextual_logger.rb
+++ b/lib/contextual_logger.rb
@@ -2,6 +2,7 @@
 
 require 'active_support'
 require 'json'
+require_relative './contextual_logger/redactor'
 require_relative './contextual_logger/context/handler'
 
 module ContextualLogger
@@ -35,6 +36,10 @@ module ContextualLogger
   end
 
   module LoggerMixin
+    def redactor
+      @redactor ||= Redactor.new
+    end
+
     def global_context=(context)
       Context::Handler.new(context).set!
     end
@@ -105,7 +110,11 @@ module ContextualLogger
     end
 
     def write_entry_to_log(severity, timestamp, progname, message, context:)
-      @logdev&.write(format_message(format_severity(severity), timestamp, progname, message, context: context))
+      @logdev&.write(
+        redactor.redact(
+          format_message(format_severity(severity), timestamp, progname, message, context: context)
+        )
+      )
     end
 
     private

--- a/lib/contextual_logger.rb
+++ b/lib/contextual_logger.rb
@@ -36,9 +36,7 @@ module ContextualLogger
   end
 
   module LoggerMixin
-    def redactor
-      @redactor ||= Redactor.new
-    end
+    delegate :register_secret, to: :redactor
 
     def global_context=(context)
       Context::Handler.new(context).set!
@@ -118,6 +116,10 @@ module ContextualLogger
     end
 
     private
+
+    def redactor
+      @redactor ||= Redactor.new
+    end
 
     def format_message(severity, timestamp, progname, message, context: {})
       message_hash = message_hash_with_context(severity, timestamp, progname, message, context: context)

--- a/lib/contextual_logger/redactor.rb
+++ b/lib/contextual_logger/redactor.rb
@@ -9,7 +9,7 @@ module ContextualLogger
       @redaction_regex = nil
     end
 
-    def match(sensitive_data)
+    def register_secret(sensitive_data)
       if redaction_set.add?(Regexp.escape(sensitive_data))
         @redaction_regex = Regexp.new(
           redaction_set.to_a.join('|')

--- a/lib/contextual_logger/redactor.rb
+++ b/lib/contextual_logger/redactor.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module ContextualLogger
+  class Redactor
+    attr_reader :redaction_set, :redaction_regex
+
+    def initialize
+      @redaction_set   = Set.new
+      @redaction_regex = nil
+    end
+
+    def match(sensitive_data)
+      if (redaction_set.add?(Regexp.escape(sensitive_data)))
+        @redaction_regex = Regexp.new(
+          redaction_set.to_a.join('|')
+        )
+      end
+    end
+
+    def redact(log_line)
+      if redaction_regex
+        log_line.gsub(redaction_regex, '<redacted>')
+      else
+        log_line
+      end
+    end
+  end
+end

--- a/lib/contextual_logger/redactor.rb
+++ b/lib/contextual_logger/redactor.rb
@@ -10,7 +10,7 @@ module ContextualLogger
     end
 
     def match(sensitive_data)
-      if (redaction_set.add?(Regexp.escape(sensitive_data)))
+      if redaction_set.add?(Regexp.escape(sensitive_data))
         @redaction_regex = Regexp.new(
           redaction_set.to_a.join('|')
         )

--- a/lib/contextual_logger/version.rb
+++ b/lib/contextual_logger/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module ContextualLogger
+  VERSION = '0.6.0'
+end

--- a/spec/lib/contextual_logger/redactor_spec.rb
+++ b/spec/lib/contextual_logger/redactor_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'contextual_logger'
+
+RSpec.describe ContextualLogger::Redactor do
+  subject { described_class.new }
+
+  describe '#match' do
+    it 'adds the new sensitive data to the redaction set' do
+      expect(subject.redaction_set).to be_empty
+      subject.match('hello')
+      expect(subject.redaction_set).to include('hello')
+    end
+
+    it 'adds the same string only once' do
+      expect(subject.redaction_set).to be_empty
+
+      subject.match('hello')
+      expect(subject.redaction_set.to_a).to eq(['hello'])
+
+      subject.match('hello')
+      expect(subject.redaction_set.to_a).to eq(['hello'])
+    end
+  end
+
+  describe '#redact' do
+    before(:each) { subject.match('hello') }
+
+    it 'redacts the sensitive data from the message' do
+      expect(subject.redact('hello world')).to eq('<redacted> world')
+    end
+
+    describe 'with multiple strings' do
+      before(:each) { subject.match('world') }
+
+      it 'redacts all sensitive data from the message' do
+        expect(subject.redact('hello world')).to eq('<redacted> <redacted>')
+      end
+    end
+  end
+end

--- a/spec/lib/contextual_logger/redactor_spec.rb
+++ b/spec/lib/contextual_logger/redactor_spec.rb
@@ -6,33 +6,33 @@ require 'contextual_logger'
 RSpec.describe ContextualLogger::Redactor do
   subject { described_class.new }
 
-  describe '#match' do
+  describe '#register_secret' do
     it 'adds the new sensitive data to the redaction set' do
       expect(subject.redaction_set).to be_empty
-      subject.match('hello')
+      subject.register_secret('hello')
       expect(subject.redaction_set).to include('hello')
     end
 
     it 'adds the same string only once' do
       expect(subject.redaction_set).to be_empty
 
-      subject.match('hello')
+      subject.register_secret('hello')
       expect(subject.redaction_set.to_a).to eq(['hello'])
 
-      subject.match('hello')
+      subject.register_secret('hello')
       expect(subject.redaction_set.to_a).to eq(['hello'])
     end
   end
 
   describe '#redact' do
-    before(:each) { subject.match('hello') }
+    before(:each) { subject.register_secret('hello') }
 
     it 'redacts the sensitive data from the message' do
       expect(subject.redact('hello world')).to eq('<redacted> world')
     end
 
     describe 'with multiple strings' do
-      before(:each) { subject.match('world') }
+      before(:each) { subject.register_secret('world') }
 
       it 'redacts all sensitive data from the message' do
         expect(subject.redact('hello world')).to eq('<redacted> <redacted>')

--- a/spec/lib/contextual_logger_spec.rb
+++ b/spec/lib/contextual_logger_spec.rb
@@ -388,14 +388,14 @@ describe ContextualLogger do
     end
 
     describe 'with sensitive data in the message' do
-      let(:expected_log_hash) {
+      let(:expected_log_hash) do
         {
           severity: 'DEBUG',
           service: 'test_service',
           message: 'this is a test with <redacted>',
           timestamp: Time.now
         }
-      }
+      end
 
       it 'replaces sensitive data with <redacted>' do
         expect_log_line_to_be_written(expected_log_hash.to_json)
@@ -404,7 +404,7 @@ describe ContextualLogger do
     end
 
     describe 'with sensitive data in the context' do
-      let(:expected_log_hash) {
+      let(:expected_log_hash) do
         {
           severity: 'DEBUG',
           service: 'test_service',
@@ -412,7 +412,7 @@ describe ContextualLogger do
           password: '<redacted>',
           timestamp: Time.now
         }
-      }
+      end
 
       it 'replaces sensitive data with <redacted>' do
         expect_log_line_to_be_written(expected_log_hash.to_json)

--- a/spec/lib/contextual_logger_spec.rb
+++ b/spec/lib/contextual_logger_spec.rb
@@ -384,7 +384,7 @@ describe ContextualLogger do
     let(:sensitive_data) { 'sensitive_string_123' }
 
     before(:each) do
-      logger.redactor.match(sensitive_data)
+      logger.register_secret(sensitive_data)
     end
 
     describe 'with sensitive data in the message' do

--- a/spec/lib/contextual_logger_spec.rb
+++ b/spec/lib/contextual_logger_spec.rb
@@ -379,4 +379,45 @@ describe ContextualLogger do
       end
     end
   end
+
+  describe 'with redaction' do
+    let(:sensitive_data) { 'sensitive_string_123' }
+
+    before(:each) do
+      logger.redactor.match(sensitive_data)
+    end
+
+    describe 'with sensitive data in the message' do
+      let(:expected_log_hash) {
+        {
+          severity: 'DEBUG',
+          service: 'test_service',
+          message: 'this is a test with <redacted>',
+          timestamp: Time.now
+        }
+      }
+
+      it 'replaces sensitive data with <redacted>' do
+        expect_log_line_to_be_written(expected_log_hash.to_json)
+        expect(logger.debug("this is a test with #{sensitive_data}", service: 'test_service')).to eq(true)
+      end
+    end
+
+    describe 'with sensitive data in the context' do
+      let(:expected_log_hash) {
+        {
+          severity: 'DEBUG',
+          service: 'test_service',
+          message: 'this is a test',
+          password: '<redacted>',
+          timestamp: Time.now
+        }
+      }
+
+      it 'replaces sensitive data with <redacted>' do
+        expect_log_line_to_be_written(expected_log_hash.to_json)
+        expect(logger.debug("this is a test", service: 'test_service', password: sensitive_data)).to eq(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Add sensitive data redaction
* __Issue Link:__ None

### Summary of Changes
This is adding the ability to register sensitive data to the logger in order for it to redact any occurrences of the sensitive strings from logs.
