### PR TITLE
Tech 4193 deprecate new overload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,19 @@
 Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - Unreleased
+### Deprecated
+- Deprecated ContextualLogger.new. It will be removed in version 1.0.
+  Instead, use `expect ContextualLogger::LoggerMixin` on a logger instance or `include ContextualLogger::LoggerMixin` in a Logger class.
+
 ## [0.6.1] - 2020-04-03
 ### Fixed
-- Gemspec to point to correct source code uri
+- Fixed gemspec to point to correct source code uri
 
 ## [0.6.0] - 2020-04-13
 ### Added
-- The ability to redact sensitive data from log entries by registering the sensitive strings ahead of time with the logger
-- `ContextualLogger#normalize_message` as a general logging helper method to normalize any message to string format.
+- Added the ability to redact sensitive data from log entries by registering the sensitive strings ahead of time with the logger
+- Added `ContextualLogger#normalize_message` as a general logging helper method to normalize any message to string format.
 
 ### Changed
 - Restored ::Logger's ability to log non-string messages like `nil` or `false`, in case there's a gem
@@ -35,6 +40,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
  - Extracted `ContextualLogger.normalize_log_level` into a public class method so we can call it elsewhere where we allow log_level to be
    configured to text values like 'debug'.
 
+[0.7.0]: https://github.com/Invoca/contextual_logger/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/Invoca/contextual_logger/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/Invoca/contextual_logger/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/Invoca/contextual_logger/compare/v0.5.0...v0.5.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    contextual_logger (0.6.1)
+    contextual_logger (0.7.0.pre.1)
       activesupport
       json
 

--- a/README.md
+++ b/README.md
@@ -19,15 +19,26 @@ gem 'contextual_logger', git: 'git://github.com/Invoca/contextual_logger.git'
 
 ## Usage
 ### Initialization
-To use the contextual logger, all you need to do is initailize the object with your existing logger
+To use the contextual logger, all you need to do is `extend` your existing logger instance:
 ```ruby
 require 'logger'
 require 'contextual_logger'
 
-logger = Logger.new(STDOUT)
-contextual_logger = ContextualLogger.new(logger)
+contextual_logger = Logger.new(STDOUT)
+contextual_logger.extend(ContextualLogger::LoggerMixin)
 ```
-**Note: This returns the original logger, mutated with the ContextualLogger mixin**
+Or, `include` it into your own Logger class:
+```ruby
+require 'logger'
+require 'contextual_logger'
+
+class ApplicationLogger < Logger
+  include ContextualLogger::LoggerMixin
+  ...
+end
+
+contextual_logger = ApplicationLogger.new(STDOUT)
+```
 
 ### Logging
 All base logging methods are available for use with _or_ without added context

--- a/lib/contextual_logger.rb
+++ b/lib/contextual_logger.rb
@@ -10,6 +10,7 @@ module ContextualLogger
     def new(logger)
       logger.extend(LoggerMixin)
     end
+    deprecate :new, deprecator: ActiveSupport::Deprecation.new('1.0', 'contextual_logger')
 
     def normalize_log_level(log_level)
       if log_level.is_a?(Integer) && (Logger::Severity::DEBUG..Logger::Severity::UNKNOWN).include?(log_level)

--- a/lib/contextual_logger/version.rb
+++ b/lib/contextual_logger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContextualLogger
-  VERSION = '0.6.1'
+  VERSION = '0.7.0.pre.1'
 end

--- a/spec/lib/contextual_logger/logger_with_context_spec.rb
+++ b/spec/lib/contextual_logger/logger_with_context_spec.rb
@@ -9,7 +9,7 @@ require 'json'
 describe ContextualLogger::LoggerWithContext do
   context "when created with a base logger" do
     let(:log_stream) { StringIO.new }
-    let(:base_logger) { ContextualLogger.new(Logger.new(log_stream, level: Logger::Severity::FATAL)) }
+    let(:base_logger) { Logger.new(log_stream, level: Logger::Severity::FATAL).extend(ContextualLogger::LoggerMixin) }
     let(:context) { { log_source: "redis_client" } }
 
     subject(:logger_with_context) { ContextualLogger::LoggerWithContext.new(base_logger, context) }

--- a/spec/lib/contextual_logger/mixins/active_support_tagged_logging_spec.rb
+++ b/spec/lib/contextual_logger/mixins/active_support_tagged_logging_spec.rb
@@ -9,7 +9,7 @@ require 'contextual_logger/overrides/active_support/tagged_logging/formatter'
 describe 'ContextualLogger::Overrides::ActiveSupport::TaggedLogging::Formatter' do
   before do
     Time.now_override = Time.now
-    @logger = ContextualLogger.new(Logger.new('/dev/null'))
+    @logger = Logger.new('/dev/null').extend(ContextualLogger::LoggerMixin)
     @logger.formatter = ->(_, _, _, msg_with_context) { "#{msg_with_context.to_json}\n" }
     @logger = ActiveSupport::TaggedLogging.new(@logger)
   end

--- a/spec/lib/contextual_logger/mixins/active_support_tagged_logging_spec.rb
+++ b/spec/lib/contextual_logger/mixins/active_support_tagged_logging_spec.rb
@@ -7,15 +7,19 @@ require 'contextual_logger'
 require 'contextual_logger/overrides/active_support/tagged_logging/formatter'
 
 describe 'ContextualLogger::Overrides::ActiveSupport::TaggedLogging::Formatter' do
+  subject do
+    logger = Logger.new('/dev/null')
+    logger.extend(ContextualLogger::LoggerMixin)
+    logger.formatter = ->(_, _, _, msg_with_context) { "#{msg_with_context.to_json}\n" }
+    ActiveSupport::TaggedLogging.new(logger)
+  end
+
   before do
     Time.now_override = Time.now
-    @logger = Logger.new('/dev/null').extend(ContextualLogger::LoggerMixin)
-    @logger.formatter = ->(_, _, _, msg_with_context) { "#{msg_with_context.to_json}\n" }
-    @logger = ActiveSupport::TaggedLogging.new(@logger)
   end
 
   it 'should log log_tags as additional context' do
-    @logger.push_tags('test')
+    subject.push_tags('test')
     expected_log_line = {
       message: 'this is a test',
       severity: 'DEBUG',
@@ -25,6 +29,6 @@ describe 'ContextualLogger::Overrides::ActiveSupport::TaggedLogging::Formatter' 
     }.to_json
 
     expect_any_instance_of(Logger::LogDevice).to receive(:write).with("#{expected_log_line}\n")
-    expect(@logger.debug('this is a test', service: 'test_service')).to eq(true)
+    expect(subject.debug('this is a test', service: 'test_service')).to eq(true)
   end
 end

--- a/spec/lib/contextual_logger_spec.rb
+++ b/spec/lib/contextual_logger_spec.rb
@@ -29,7 +29,7 @@ describe ContextualLogger do
   context 'with logger writing to log_stream' do
     let(:log_stream) { StringIO.new }
     let(:log_level) { Logger::Severity::DEBUG }
-    let(:logger) { ContextualLogger.new(Logger.new(log_stream, level: log_level)) }
+    let(:logger) { Logger.new(log_stream, level: log_level).extend(ContextualLogger::LoggerMixin) }
 
     describe 'log level' do
       context 'at default level' do
@@ -104,7 +104,7 @@ describe ContextualLogger do
         log_at_every_level(broadcast_logger, service: 'test_service')
         expect(log_message_levels).to eq(["error", "fatal", "unknown"])
         # note: context lands in `progname` arg
-        expect(console_log_stream.string.gsub(/\[[^]]+\]/, '[]')).to eq(<<~EOS)
+        expect(console_log_stream.string.gsub(/\[[^\]]+\]/, '[]')).to eq(<<~EOS)
           D, [] DEBUG -- {:service=>\"test_service\"}: debug message
           I, []  INFO -- {:service=>\"test_service\"}: info message
           W, []  WARN -- {:service=>\"test_service\"}: warn message
@@ -118,7 +118,7 @@ describe ContextualLogger do
         broadcast_logger.add(Logger::Severity::ERROR, "error message", service: 'test_service')
         expect(log_message_levels).to eq(["error"])
         # note: context lands in `progname` arg
-        expect(console_log_stream.string.gsub(/\[[^]]+\]/, '[]')).to eq("E, [] ERROR -- {:service=>\"test_service\"}: error message\n")
+        expect(console_log_stream.string.gsub(/\[[^\]]+\]/, '[]')).to eq("E, [] ERROR -- {:service=>\"test_service\"}: error message\n")
       end
     end
 
@@ -347,7 +347,7 @@ describe ContextualLogger do
 
   describe 'add' do
     let(:log_stream) { StringIO.new }
-    let(:logger) { ContextualLogger.new(Logger.new(log_stream, level: Logger::Severity::DEBUG)) }
+    let(:logger) { Logger.new(log_stream, level: Logger::Severity::DEBUG).extend(ContextualLogger::LoggerMixin) }
 
     it "preserves the Logger interface with message only" do
       expect(logger.add(Logger::Severity::INFO, "info message")).to eq(true)
@@ -379,7 +379,7 @@ describe ContextualLogger do
     describe "normalize_log_level" do
       it "raises an exception on invalid values" do
         [nil, "", "ABC", 3.5].each do |invalid_value|
-          expect { ContextualLogger.normalize_log_level(invalid_value) }.to raise_exception(ArgumentError, /invalid log level:/), invalid_value
+          expect { ContextualLogger.normalize_log_level(invalid_value) }.to raise_exception(ArgumentError, /invalid log level:/), invalid_value.inspect
         end
       end
 
@@ -501,12 +501,13 @@ describe ContextualLogger do
     subject { ContextualLogger.new(raw_logger) }
 
     it 'is redacted' do
-      expect_any_instance_of(ActiveSupport::Deprecation).to receive(:deprecation_warning).with(:new, nil)
+      expect(STDERR).to receive(:puts).with(/DEPRECATION WARNING: new is deprecated and will be removed from contextual_logger 1\.0/)
 
       subject
     end
 
     it 'returns the logger with a mixin prepended' do
+      expect(STDERR).to receive(:puts).with(anything)
       result = subject
 
       expect(result).to be(subject)


### PR DESCRIPTION
## [0.7.0] - Unreleased
### Deprecated
- Deprecated ContextualLogger.new. It will be removed in version 1.0.
  Instead, use `expect ContextualLogger::LoggerMixin` on a logger instance or `include ContextualLogger::LoggerMixin` in a Logger class.
