### PR TITLE
Tech 4608 remove unnecessary timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - Unreleased
+### Removed
+- Removed unnecessary duplicate context (`severity`, `timestamp`, and `progname`) in message hash passed to formatter. These
+are already passed to the formatter as arguments so that the formatter and decided how to add them to the log line.
+
 ## [0.8.0] - 2020-05-15
 ### Added
 - Added support for rails 5 and 6.
@@ -52,6 +57,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
  - Extracted `ContextualLogger.normalize_log_level` into a public class method so we can call it elsewhere where we allow log_level to be
    configured to text values like 'debug'.
 
+[0.9.0]: https://github.com/Invoca/contextual_logger/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Invoca/contextual_logger/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Invoca/contextual_logger/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/Invoca/contextual_logger/compare/v0.6.0...v0.6.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    contextual_logger (0.8.0)
+    contextual_logger (0.9.0.pre.1)
       activesupport
       json
 

--- a/lib/contextual_logger.rb
+++ b/lib/contextual_logger.rb
@@ -136,11 +136,11 @@ module ContextualLogger
       if @formatter
         @formatter.call(severity, timestamp, progname, { message: ContextualLogger.normalize_message(message), **context })
       else
-        "#{basic_message_formatting(severity, timestamp, progname, message, context: context)}\n"
+        "#{basic_json_log_entry(severity, timestamp, progname, message, context: context)}\n"
       end
     end
 
-    def basic_message_formatting(severity, timestamp, progname, message, context:)
+    def basic_json_log_entry(severity, timestamp, progname, message, context:)
       message_hash = {
         message:   ContextualLogger.normalize_message(message),
         severity:  severity,

--- a/lib/contextual_logger.rb
+++ b/lib/contextual_logger.rb
@@ -133,25 +133,21 @@ module ContextualLogger
     end
 
     def format_message(severity, timestamp, progname, message, context: {})
-      message_hash = message_hash_with_context(severity, timestamp, progname, message, context: context)
-
       if @formatter
-        @formatter.call(severity, timestamp, progname, message_hash)
+        @formatter.call(severity, timestamp, progname, { message: ContextualLogger.normalize_message(message), **context })
       else
-        "#{message_hash.to_json}\n"
+        "#{basic_message_formatting(severity, timestamp, progname, message, context: context).to_json}\n"
       end
     end
 
-    def message_hash_with_context(severity, timestamp, progname, message, context:)
-      message_hash =
-        {
-          message:   ContextualLogger.normalize_message(message),
-          severity:  severity,
-          timestamp: timestamp
-        }
+    def basic_message_formatting(severity, timestamp, progname, message, context:)
+      message_hash = {
+        message:   ContextualLogger.normalize_message(message),
+        severity:  severity,
+        timestamp: timestamp
+      }
       message_hash[:progname] = progname if progname
-
-      message_hash.merge!(context)
+      message_hash.merge(context)
     end
   end
 end

--- a/lib/contextual_logger.rb
+++ b/lib/contextual_logger.rb
@@ -136,7 +136,7 @@ module ContextualLogger
       if @formatter
         @formatter.call(severity, timestamp, progname, { message: ContextualLogger.normalize_message(message), **context })
       else
-        "#{basic_message_formatting(severity, timestamp, progname, message, context: context).to_json}\n"
+        "#{basic_message_formatting(severity, timestamp, progname, message, context: context)}\n"
       end
     end
 
@@ -147,7 +147,9 @@ module ContextualLogger
         timestamp: timestamp
       }
       message_hash[:progname] = progname if progname
-      message_hash.merge(context)
+
+      # using merge! instead of merge for speed of operation
+      message_hash.merge!(context).to_json
     end
   end
 end

--- a/lib/contextual_logger/version.rb
+++ b/lib/contextual_logger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContextualLogger
-  VERSION = '0.9.0'
+  VERSION = '0.9.0.pre.1'
 end

--- a/lib/contextual_logger/version.rb
+++ b/lib/contextual_logger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContextualLogger
-  VERSION = '0.8.0'
+  VERSION = '0.9.0'
 end

--- a/spec/lib/contextual_logger/mixins/active_support_tagged_logging_spec.rb
+++ b/spec/lib/contextual_logger/mixins/active_support_tagged_logging_spec.rb
@@ -23,8 +23,6 @@ describe 'ContextualLogger::Overrides::ActiveSupport::TaggedLogging::Formatter' 
     subject.push_tags('test')
     expected_log_line = {
       message: 'this is a test',
-      severity: 'DEBUG',
-      timestamp: Time.now,
       service: 'test_service',
       log_tags: 'test'
     }.to_json


### PR DESCRIPTION
## [0.9.0] - Unreleased
### Removed
- Removed unnecessary duplicate context (`severity`, `timestamp`, and `progname`) in message hash passed to formatter. These are already passed to the formatter as arguments so that the formatter and decided how to add them to the log line.
