### PR TITLE
Removing hardcoded ruby version from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: ruby
-rvm:
-  - 2.4.5
 dist: trusty
 install:
   - bundle install --jobs=3 --retry=3


### PR DESCRIPTION

## Updating travis config
* The .ruby-version file should be used now: https://docs.travis-ci.com/user/languages/ruby/#using-ruby-version

### Summary of Changes
* Removing rvm reference with specific ruby version that has drifted
