### PR TITLE
TECH-4787: support progname and message block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - Unreleased
+### Added
+- Added support for all combinations of `logger.info('progname', context_key: value) { 'message' }`.
+
+### Fixed
+- Fixed bug where usage like in Faraday: `logger.info('progname') { 'message' }` was dropping the message and only showing
+  `progname`.
+- Fixed bug where message block would get called (and could be slow) even if the log_level was not enabled.
+
+
 ## [0.9.1] - 2020-08-18
 ### Fixed
 - Fixed bug where merging context with string keys was causing a "key" is not a Symbol error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # CHANGELOG for `contextual_logger`
 
 Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.10.0] - Unreleased
+## [0.10.0] - 2020-09-02
 ### Added
 - Added support and tests for all combinations of `progname`, `message`, and `context`:
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,23 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 ## [0.10.0] - Unreleased
 ### Added
-- Added support for all combinations of `logger.info('progname', context_key: value) { 'message' }`.
+- Added support and tests for all combinations of `progname`, `message`, and `context`:
+```
+logger.info(message)
+logger.info(context_key1: value, context_key2: value)
+logger.info(message, context_key1: value, context_key2: value)
+logger.info { message }
+logger.info(progname) { message }
+logger.info(context_key1: value, context_key2: value) { message }
+logger.info(progname, context_key1: value, context_key2: value) { message }
+```
+including where `progname` and `message` are types other than `String`.
 
 ### Fixed
-- Fixed bug where usage like in Faraday: `logger.info('progname') { 'message' }` was dropping the message and only showing
+- Fixed bug where usage like in Faraday: `logger.info(progname) { message }` was dropping the message and only showing
   `progname`.
-- Fixed bug where message block would get called (and could be slow) even if the log_level was not enabled.
-
+- Fixed bug in block form where the message block would be called even if the log_level was not enabled
+  (this could have been slow).
 
 ## [0.9.1] - 2020-08-18
 ### Fixed
@@ -71,6 +81,7 @@ are already passed to the formatter as arguments so that the formatter and decid
  - Extracted `ContextualLogger.normalize_log_level` into a public class method so we can call it elsewhere where we allow log_level to be
    configured to text values like 'debug'.
 
+[0.10.0]: https://github.com/Invoca/contextual_logger/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/Invoca/contextual_logger/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/Invoca/contextual_logger/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Invoca/contextual_logger/compare/v0.7.0...v0.8.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    contextual_logger (0.9.1)
+    contextual_logger (0.10.0.pre.1)
       activesupport
       json
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    contextual_logger (0.10.0.pre.1)
+    contextual_logger (0.10.0)
       activesupport
       json
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ All base logging methods are available for use with _or_ without added context
 contextual_logger.info('Something might have just happened', file: __FILE__, current_object: inspect)
 ```
 
+The block form with optional 'progname' is also supported. As with ::Logger: the block is only called if the log level is enabled.
+```ruby
+contextual_logger.debug('progname', current_id: current_object.id) { "debug info: #{expensive_debug_function}" }
+```
+
 If there is a base set of context you'd like to apply to a block of code, simply wrap it in `#with_context`
 ```ruby
 contextual_logger.with_context(file: __FILE__, current_object: inspect) do

--- a/lib/contextual_logger.rb
+++ b/lib/contextual_logger.rb
@@ -70,11 +70,11 @@ module ContextualLogger
 
     # In the methods generated below, we assume that presence of context means new code that is
     # aware of ContextualLogger...and that that code never uses progname.
-    # This is important because we only get 2 args total (plus &block) passed to add(), in order to be
-    # compatible with classic implementations like in the plain Logger and
+    # This is important because we only get 3 args total (not including &block) passed to `add`,
+    # in order to be compatible with classic implementations like in the plain ::Logger and
     # ActiveSupport::Logger.broadcast.
 
-    # Note that we can't yield before add because `add` might skip it based on log_level. And we can't check
+    # Note that we can't yield before `add` because `add` might skip it based on log_level. And we can't check
     # log_level here because we might be running in ActiveSupport::Logging.broadcast which has multiple
     # loggers, each with their own log_level.
 
@@ -87,7 +87,9 @@ module ContextualLogger
             if arg.nil?
               add(#{log_level}, nil, context, &block)
             elsif block
-              add(#{log_level}, nil, context) { "\#{arg}: \#{block.call}" }
+              add(#{log_level}, nil, context) do
+                "\#{ContextualLogger.normalize_message(arg)}: \#{ContextualLogger.normalize_message(block.call)}"
+              end
             else
               add(#{log_level}, arg, context)
             end

--- a/lib/contextual_logger.rb
+++ b/lib/contextual_logger.rb
@@ -106,7 +106,7 @@ module ContextualLogger
         if arg1.nil?
           if block_given?
             message = yield
-            progname = arg2 || context[:progname] || @progname
+            progname = arg2 || context.delete(:progname) || @progname
           else
             message = arg2
             progname = @progname

--- a/lib/contextual_logger.rb
+++ b/lib/contextual_logger.rb
@@ -100,6 +100,8 @@ module ContextualLogger
       severity >= level
     end
 
+    # Note that this interface needs to stay compatible with the underlying ::Logger#add interface,
+    # which is: def add(severity, message = nil, progname = nil)
     def add(arg_severity, arg1 = nil, arg2 = nil, **context)   # Ruby will prefer to match hashes up to last ** argument
       severity = arg_severity || UNKNOWN
       if log_level_enabled?(severity)

--- a/lib/contextual_logger.rb
+++ b/lib/contextual_logger.rb
@@ -75,7 +75,7 @@ module ContextualLogger
     # and ActiveSupport::Logger.broadcast.
 
     LOG_LEVEL_NAMES_TO_SEVERITY.each do |method_name, log_level|
-      eval <<~EOS
+      class_eval(<<~EOS, __FILE__, __LINE__ + 1)
         def #{method_name}(arg = nil, context = nil, &block)
           if context
             add(#{log_level}, arg, context, &block)

--- a/lib/contextual_logger.rb
+++ b/lib/contextual_logger.rb
@@ -106,11 +106,7 @@ module ContextualLogger
         if arg1.nil?
           if block_given?
             message = yield
-            if arg2.nil? && context.has_key?(:progname)
-              progname = context[:progname] || @progname
-            else
-              progname = arg2 || @progname
-            end
+            progname = arg2 || context[:progname] || @progname
           else
             message = arg2
             progname = @progname

--- a/lib/contextual_logger/version.rb
+++ b/lib/contextual_logger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContextualLogger
-  VERSION = '0.9.1'
+  VERSION = '0.10.0.pre.1'
 end

--- a/lib/contextual_logger/version.rb
+++ b/lib/contextual_logger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContextualLogger
-  VERSION = '0.10.0.pre.1'
+  VERSION = '0.10.0'
 end

--- a/spec/lib/contextual_logger_spec.rb
+++ b/spec/lib/contextual_logger_spec.rb
@@ -205,8 +205,16 @@ describe ContextualLogger do
       let(:message) { 'request: this is a test' }
 
       it 'handles message block (inline context) with progname' do
-        expect_log_line_to_be_written(expected_log_hash.merge(progname: 'request').to_json)
+        formatter_args = []
+        logger.formatter = -> (*args) do
+          formatter_args = args
+          '"message"'
+        end
+        expect_log_line_to_be_written('"message"')
         expect(logger.info('request', service: 'test_service') { 'this is a test' }).to eq(true)
+
+        expect(formatter_args[2]).to eq('request')
+        expect(formatter_args[3]).to eq(message: "this is a test", service: "test_service")
       end
     end
 

--- a/spec/lib/contextual_logger_spec.rb
+++ b/spec/lib/contextual_logger_spec.rb
@@ -194,12 +194,14 @@ describe ContextualLogger do
     end
 
     context "when log level isn't enabled" do
-      before { logger.level = Logger::Severity::ERROR }
+      before { logger.level = Logger::Severity::UNKNOWN }
 
-      it "does not call message block" do
-        block_called = false
-        logger.info(nil, service: 'test_service') { block_called = true }
-        expect(block_called).to be_falsey
+      [:debug, :info, :warn, :error, :fatal].each do |level|
+        it "does not call message block (#{level})" do
+          block_called = false
+          logger.send(level, nil, service: 'test_service') { block_called = true }
+          expect(block_called).to be_falsey
+        end
       end
     end
   end

--- a/spec/lib/contextual_logger_spec.rb
+++ b/spec/lib/contextual_logger_spec.rb
@@ -155,6 +155,55 @@ describe ContextualLogger do
     end
   end
 
+  context 'with no context' do
+    let(:expected_log_hash) do
+      {
+        message: 'this is a test',
+        timestamp: Time.now,
+        progname: 'request'
+      }
+    end
+
+    it 'handles both progname and message block (no inline context)' do
+      expect_log_line_to_be_written(expected_log_hash.merge(severity: 'INFO').to_json)
+      expect(logger.info('request') { 'this is a test' }).to eq(true)
+    end
+
+    context "when log level isn't enabled" do
+      before { logger.level = Logger::Severity::ERROR }
+
+      it "does not call message block" do
+        block_called = false
+        logger.info('request') { block_called = true }
+        expect(block_called).to be_falsey
+      end
+    end
+  end
+
+  context 'inline context' do
+    let(:expected_log_hash) do
+      {
+        message: 'this is a test',
+        timestamp: Time.now
+      }
+    end
+
+    it 'handles message block (inline context)' do
+      expect_log_line_to_be_written(expected_log_hash.merge(severity: 'INFO', service: 'test_service').to_json)
+      expect(logger.info(nil, service: 'test_service') { 'this is a test' }).to eq(true)
+    end
+
+    context "when log level isn't enabled" do
+      before { logger.level = Logger::Severity::ERROR }
+
+      it "does not call message block" do
+        block_called = false
+        logger.info(nil, service: 'test_service') { block_called = true }
+        expect(block_called).to be_falsey
+      end
+    end
+  end
+
   describe 'inline context' do
     let(:expected_log_hash) do
       {

--- a/spec/lib/contextual_logger_spec.rb
+++ b/spec/lib/contextual_logger_spec.rb
@@ -210,6 +210,15 @@ describe ContextualLogger do
       end
     end
 
+    context 'with non-String progname and message' do
+      let(:message) { ':progname: :test' }
+
+      it 'handles message block (inline context) with progname' do
+        expect_log_line_to_be_written(expected_log_hash.to_json)
+        expect(logger.info(:progname, service: 'test_service') { :test }).to eq(true)
+      end
+    end
+
     context "when log level isn't enabled" do
       before { logger.level = Logger::Severity::UNKNOWN }
 

--- a/spec/lib/contextual_logger_spec.rb
+++ b/spec/lib/contextual_logger_spec.rb
@@ -158,7 +158,7 @@ describe ContextualLogger do
   context 'with no context' do
     let(:expected_log_hash) do
       {
-        message: 'this is a test',
+        message: 'request: this is a test',
         timestamp: Time.now,
         progname: 'request'
       }
@@ -205,17 +205,8 @@ describe ContextualLogger do
       let(:message) { 'request: this is a test' }
 
       it 'handles message block (inline context) with progname' do
-        expect_log_line_to_be_written(expected_log_hash.to_json)
+        expect_log_line_to_be_written(expected_log_hash.merge(progname: 'request').to_json)
         expect(logger.info('request', service: 'test_service') { 'this is a test' }).to eq(true)
-      end
-    end
-
-    context 'with non-String progname and message' do
-      let(:message) { ':progname: :test' }
-
-      it 'handles message block (inline context) with progname' do
-        expect_log_line_to_be_written(expected_log_hash.to_json)
-        expect(logger.info(:progname, service: 'test_service') { :test }).to eq(true)
       end
     end
 
@@ -438,7 +429,7 @@ describe ContextualLogger do
 
     it "preserves the Logger interface with non-nil progname & block" do
       expect(logger.add(Logger::Severity::INFO, nil, 'request') { "info message" }).to eq(true)
-      expect(log_stream.string).to match(/\{"message":"info message","severity":"INFO","timestamp":".*","progname":"request"\}/)
+      expect(log_stream.string).to match(/\{"message":"request: info message","severity":"INFO","timestamp":".*","progname":"request"\}/)
     end
 
     it "preserves the Logger interface with nil message & message in progname spot" do

--- a/spec/lib/contextual_logger_spec.rb
+++ b/spec/lib/contextual_logger_spec.rb
@@ -359,6 +359,11 @@ describe ContextualLogger do
       expect(log_stream.string).to match(/\{"message":"info message","severity":"INFO","timestamp":".*"\}/)
     end
 
+    it "preserves the Logger interface with non-nil progname & block" do
+      expect(logger.add(Logger::Severity::INFO, nil, 'request') { "info message" }).to eq(true)
+      expect(log_stream.string).to match(/\{"message":"info message","severity":"INFO","timestamp":".*","progname":"request"\}/)
+    end
+
     it "preserves the Logger interface with nil message & message in progname spot" do
       expect(logger.add(Logger::Severity::INFO, nil, "info message")).to eq(true)
       expect(log_stream.string).to match(/\{"message":"info message","severity":"INFO","timestamp":".*"\}/)

--- a/spec/lib/contextual_logger_spec.rb
+++ b/spec/lib/contextual_logger_spec.rb
@@ -181,16 +181,33 @@ describe ContextualLogger do
   end
 
   context 'inline context' do
+    let(:message) { 'this is a test' }
     let(:expected_log_hash) do
       {
-        message: 'this is a test',
-        timestamp: Time.now
+        severity: 'INFO',
+        message: message,
+        timestamp: Time.now,
+        service: 'test_service'
       }
     end
 
-    it 'handles message block (inline context)' do
-      expect_log_line_to_be_written(expected_log_hash.merge(severity: 'INFO', service: 'test_service').to_json)
+    it 'handles message block (inline context) with nil progname' do
+      expect_log_line_to_be_written(expected_log_hash.to_json)
       expect(logger.info(nil, service: 'test_service') { 'this is a test' }).to eq(true)
+    end
+
+    it 'handles message block (inline context) with no progname' do
+      expect_log_line_to_be_written(expected_log_hash.to_json)
+      expect(logger.info(service: 'test_service') { 'this is a test' }).to eq(true)
+    end
+
+    context 'with progname and message' do
+      let(:message) { 'request: this is a test' }
+
+      it 'handles message block (inline context) with progname' do
+        expect_log_line_to_be_written(expected_log_hash.to_json)
+        expect(logger.info('request', service: 'test_service') { 'this is a test' }).to eq(true)
+      end
     end
 
     context "when log level isn't enabled" do


### PR DESCRIPTION
TECH-4787

## [0.10.0] - Unreleased
### Added
- Added support and tests for all combinations of `progname`, `message`, and `context`:
```
logger.info(message)
logger.info(context_key1: value, context_key2: value)
logger.info(message, context_key1: value, context_key2: value)
logger.info { message }
logger.info(progname) { message }
logger.info(context_key1: value, context_key2: value) { message }
logger.info(progname, context_key1: value, context_key2: value) { message }
```
including where `progname` and `message` are types other than `String`.

### Fixed
- Fixed bug where usage like in Faraday: `logger.info(progname) { message }` was dropping the message and only showing
  `progname`.
- Fixed bug in block form where the message block would be called even if the log_level was not enabled
  (this could have been slow).