### PR TITLE
Add the ability to strictly enforce context shape within the logger

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -2,4 +2,4 @@
 --color
 --format RspecJunitFormatter
 --out spec/reports/rspec.xml
--fd
+--format progress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - Unreleased
+### Added
+- Added a new interface for defining the expected structure of the logger's context
+- Added the ability to strictly enforce the structure of the logger's context by
+removing all undefined context keys
+- Added the ability to raise when attempting to apply context with undefined keys
+
 ## [0.11.0] - 2020-09-15
 ### Changed
 - Updated contextual logger to normalize keys to symbols and warn on string keys

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    contextual_logger (0.11.0)
+    contextual_logger (0.12.0.pre.1)
       activesupport
       json
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ contextual_logger.register_context do
   # This makes it so that the logger will not raise a MissingDefinitionError
   # when code tries to apply a context key that does not map to a definition
   # in the registry
-  raise_on_definition_missing false
+  raise_on_missing_definition false
 
   string :service_name
 
@@ -194,13 +194,13 @@ end
 ### Production Best Practices
 
 In `production` environments it is best to protect your logging from excess bloat by
-setting `strict` to `true`, and `raise_on_definition_missing` to `false` in order
+setting `strict` to `true`, and `raise_on_missing_definition` to `false` in order
 to protect against logging causing unnecessary errors.
 
 ```ruby
 contextual_logger.register_context do
   strict true
-  raise_on_definition_missing false
+  raise_on_missing_definition false
 end
 ```
 
@@ -208,12 +208,12 @@ end
 
 When running in `test` and `development` environments it is best to be quickly aware
 that context is being erroniously added to the logs by setting both `strict` and
-`raise_on_definition_missing` to `true`.
+`raise_on_missing_definition` to `true`.
 
 ```ruby
 contextual_logger.register_context do
   strict true
-  raise_on_definition_missing true
+  raise_on_missing_definition true
 end
 ```
 
@@ -221,8 +221,8 @@ end
 
 | Config | Description | Default |
 | ------ | :---------: | ------: |
-| `strict` | | `true` |
-| `raise_on_definition_missing` | | `true` |
+| `strict` | When enabled the logger will enforce the shape of the context specified by dropping context keys that are not definied and running formatters across the data | `true` |
+| `raise_on_missing_definition` | When enabled, the logger will raise and exception if a context key is added to the logger that does not have a definition defined | `true` |
 
 ### Available Definitions
 

--- a/lib/contextual_logger.rb
+++ b/lib/contextual_logger.rb
@@ -46,7 +46,7 @@ module ContextualLogger
   module LoggerMixin
     delegate :register_secret, to: :redactor
 
-    def configure_context(&block)
+    def register_context(&block)
       block or raise ArgumentError, 'Block of context definitions was not passed'
       @context_registry = Context::Registry.new(&block)
     end

--- a/lib/contextual_logger.rb
+++ b/lib/contextual_logger.rb
@@ -5,6 +5,7 @@ require 'active_support/core_ext/module/delegation'
 require 'json'
 require_relative './contextual_logger/redactor'
 require_relative './contextual_logger/context/handler'
+require_relative './contextual_logger/context/registry'
 
 module ContextualLogger
   LOG_LEVEL_NAMES_TO_SEVERITY =
@@ -44,6 +45,11 @@ module ContextualLogger
 
   module LoggerMixin
     delegate :register_secret, to: :redactor
+
+    def configure_context(&block)
+      block or raise ArgumentError, 'Block of context definitions was not passed'
+      @context_registry = Context::Registry.new(&block)
+    end
 
     def global_context=(context)
       Context::Handler.new(context).set!

--- a/lib/contextual_logger.rb
+++ b/lib/contextual_logger.rb
@@ -56,7 +56,12 @@ module ContextualLogger
     end
 
     def with_context(context)
-      context_handler = Context::Handler.new(current_context_for_thread.deep_merge(context))
+      context_handler = Context::Handler.new(
+        current_context_for_thread.deep_merge(
+          context_registry.format(context)
+        )
+      )
+
       context_handler.set!
       if block_given?
         begin

--- a/lib/contextual_logger.rb
+++ b/lib/contextual_logger.rb
@@ -128,7 +128,7 @@ module ContextualLogger
           message = arg1
           progname = arg2 || @progname
         end
-        write_entry_to_log(severity, Time.now, progname, message, context: current_context_for_thread.deep_merge(context))
+        write_entry_to_log(severity, Time.now, progname, message, context: current_context_for_thread.deep_merge(context_registry.format(context)))
       end
 
       true

--- a/lib/contextual_logger.rb
+++ b/lib/contextual_logger.rb
@@ -52,7 +52,7 @@ module ContextualLogger
     end
 
     def global_context=(context)
-      Context::Handler.new(context).set!
+      Context::Handler.new(context_registry.format(context)).set!
     end
 
     def with_context(context)

--- a/lib/contextual_logger.rb
+++ b/lib/contextual_logger.rb
@@ -145,7 +145,10 @@ module ContextualLogger
     private
 
     def context_registry
-      @context_registry ||= Context::Registry.new { strict false }
+      @context_registry ||= Context::Registry.new do
+        strict false
+        raise_on_missing_definition false
+      end
     end
 
     def redactor

--- a/lib/contextual_logger.rb
+++ b/lib/contextual_logger.rb
@@ -139,6 +139,10 @@ module ContextualLogger
 
     private
 
+    def context_registry
+      @context_registry ||= Context::Registry.new { strict false }
+    end
+
     def redactor
       @redactor ||= Redactor.new
     end

--- a/lib/contextual_logger/context/handler.rb
+++ b/lib/contextual_logger/context/handler.rb
@@ -7,8 +7,10 @@ module ContextualLogger
 
       attr_reader :previous_context, :context
 
-      def self.current_context
-        Thread.current[THREAD_CONTEXT_NAMESPACE] || {}
+      class << self
+        def current_context
+          Thread.current[THREAD_CONTEXT_NAMESPACE] || {}
+        end
       end
 
       def initialize(context, previous_context: nil)

--- a/lib/contextual_logger/context/registry.rb
+++ b/lib/contextual_logger/context/registry.rb
@@ -7,7 +7,8 @@ require_relative 'registry_types/date'
 require_relative 'registry_types/hash'
 
 # This class is responsible for holding the registered context shape that will
-# be used by the Context::Handler to make sure that the context matches the shape
+# be used by the LoggerMixin to make sure that the context matches the shape
+# defined
 
 # logger.configure_context do
 #   strict false
@@ -24,9 +25,12 @@ module ContextualLogger
   module Context
     class Registry < RegistryTypes::Hash
       class DuplicateDefinitionError < StandardError; end
+      class MissingDefinitionError < StandardError; end
 
       def initialize(&definitions)
-        @strict = true
+        @strict                        = true
+        @raise_on_missing_definition = true
+
         super
       end
 
@@ -34,9 +38,13 @@ module ContextualLogger
         @strict
       end
 
+      def raise_on_missing_definition?
+        @raise_on_missing_definition
+      end
+
       def format(context)
         if strict?
-          super
+          super(context, raise_on_missing_definition?)
         else
           context
         end
@@ -55,6 +63,10 @@ module ContextualLogger
 
       def strict(value)
         @strict = value
+      end
+
+      def raise_on_missing_definition(value)
+        @raise_on_missing_definition = value
       end
     end
   end

--- a/lib/contextual_logger/context/registry.rb
+++ b/lib/contextual_logger/context/registry.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require_relative 'registry_types/string'
+require_relative 'registry_types/boolean'
+require_relative 'registry_types/number'
+require_relative 'registry_types/date'
+
+# This class is responsible for holding the registered context shape that will
+# be used by the Context::Handler to make sure that the context matches the shape
+
+# logger.configure_context do
+#   strict false
+#
+#   string test_string
+#   integer test_integer
+#   hash :test_hash do
+#     string :test_string_in_hash
+#     date :date_time_in_hash
+#   end
+# end
+
+module ContextualLogger
+  module Context
+    class Registry
+      class DuplicateDefinitionError < StandardError; end
+
+      attr_reader :context_shape
+
+      def initialize(&definitions)
+        @strict        = true
+        @context_shape = {}
+
+        run(&definitions)
+      end
+
+      def strict?
+        @strict
+      end
+
+      def context_shape_hash
+        context_shape.reduce({}) { |shape_hash, (key, value)| shape_hash.merge(key => value.to_h) }
+      end
+
+      private
+
+      def strict(value)
+        @strict = value
+      end
+
+      def string(context_key, formatter: nil)
+        dedup(context_key, :string)
+        @context_shape[context_key] = RegistryTypes::String.new(formatter: formatter)
+      end
+
+      def boolean(context_key, formatter: nil)
+        dedup(context_key, :boolean)
+        @context_shape[context_key] = RegistryTypes::Boolean.new(formatter: formatter)
+      end
+
+      def number(context_key, formatter: nil)
+        dedup(context_key, :number)
+        @context_shape[context_key] = RegistryTypes::Number.new(formatter: formatter)
+      end
+
+      def date(context_key, formatter: nil)
+        dedup(context_key, :date)
+        @context_shape[context_key] = RegistryTypes::Date.new(formatter: formatter)
+      end
+
+      def run(&definitions)
+        instance_eval(&definitions)
+      end
+
+      def dedup(key, type)
+        @context_shape.include?(key) and
+          raise DuplicateDefinitionError, "Defining duplicate entry #{key} previously as #{@context_shape[key]} and now as #{type}"
+      end
+    end
+  end
+end

--- a/lib/contextual_logger/context/registry.rb
+++ b/lib/contextual_logger/context/registry.rb
@@ -28,7 +28,7 @@ module ContextualLogger
       class MissingDefinitionError < StandardError; end
 
       def initialize(&definitions)
-        @strict                        = true
+        @strict                      = true
         @raise_on_missing_definition = true
 
         super
@@ -61,11 +61,11 @@ module ContextualLogger
 
       private
 
-      def strict(value)
+      def strict(value) # rubocop:disable Style/TrivialAccessors
         @strict = value
       end
 
-      def raise_on_missing_definition(value)
+      def raise_on_missing_definition(value) # rubocop:disable Style/TrivialAccessors
         @raise_on_missing_definition = value
       end
     end

--- a/lib/contextual_logger/context/registry.rb
+++ b/lib/contextual_logger/context/registry.rb
@@ -34,6 +34,14 @@ module ContextualLogger
         @strict
       end
 
+      def format(context)
+        if strict?
+          super
+        else
+          context
+        end
+      end
+
       alias context_shape to_h
 
       def to_h

--- a/lib/contextual_logger/context/registry_types/boolean.rb
+++ b/lib/contextual_logger/context/registry_types/boolean.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ContextualLogger
+  module Context
+    module RegistryTypes
+      class Boolean
+        attr_reader :formatter
+
+        def initialize(formatter: nil)
+          @formatter = formatter || ->(value) { value ? true : false }
+        end
+
+        def to_h
+          { type: :boolean, formatter: formatter }
+        end
+      end
+    end
+  end
+end

--- a/lib/contextual_logger/context/registry_types/boolean.rb
+++ b/lib/contextual_logger/context/registry_types/boolean.rb
@@ -13,6 +13,15 @@ module ContextualLogger
         def to_h
           { type: :boolean, formatter: formatter }
         end
+
+        def format(value)
+          case formatter
+          when Proc
+            formatter.call(value)
+          else
+            value.send(formatter)
+          end
+        end
       end
     end
   end

--- a/lib/contextual_logger/context/registry_types/date.rb
+++ b/lib/contextual_logger/context/registry_types/date.rb
@@ -13,6 +13,15 @@ module ContextualLogger
         def to_h
           { type: :date, formatter: formatter }
         end
+
+        def format(value)
+          case formatter
+          when Proc
+            formatter.call(value)
+          else
+            value.send(formatter)
+          end
+        end
       end
     end
   end

--- a/lib/contextual_logger/context/registry_types/date.rb
+++ b/lib/contextual_logger/context/registry_types/date.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ContextualLogger
+  module Context
+    module RegistryTypes
+      class Date
+        attr_reader :formatter
+
+        def initialize(formatter: nil)
+          @formatter = formatter || ->(value) { value.iso8601(6) }
+        end
+
+        def to_h
+          { type: :date, formatter: formatter }
+        end
+      end
+    end
+  end
+end

--- a/lib/contextual_logger/context/registry_types/hash.rb
+++ b/lib/contextual_logger/context/registry_types/hash.rb
@@ -21,10 +21,16 @@ module ContextualLogger
           end
         end
 
-        def format(context)
+        def format(context, raise_on_missing_definition)
           context.reduce({}) do |formatted_context, (key, value)|
             if (definition = @definitions[key])
-              formatted_context[key] = definition.format(value)
+              formatted_context[key] = if definition.is_a?(RegistryTypes::Hash)
+                                         definition.format(value, raise_on_missing_definition)
+                                       else
+                                         definition.format(value)
+                                       end
+            elsif raise_on_missing_definition
+              raise Registry::MissingDefinitionError, "Attempting to apply context #{key} that is missing a definition in the registry"
             end
 
             formatted_context

--- a/lib/contextual_logger/context/registry_types/hash.rb
+++ b/lib/contextual_logger/context/registry_types/hash.rb
@@ -21,6 +21,16 @@ module ContextualLogger
           end
         end
 
+        def format(context)
+          context.reduce({}) do |formatted_context, (key, value)|
+            if (definition = @definitions[key])
+              formatted_context[key] = definition.format(value)
+            end
+
+            formatted_context
+          end
+        end
+
         private
 
         def string(context_key, formatter: nil)

--- a/lib/contextual_logger/context/registry_types/hash.rb
+++ b/lib/contextual_logger/context/registry_types/hash.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative 'string'
+require_relative 'boolean'
+require_relative 'number'
+require_relative 'date'
+
+module ContextualLogger
+  module Context
+    module RegistryTypes
+      class Hash
+        def initialize(&definitions)
+          @definitions = {}
+
+          run(&definitions)
+        end
+
+        def to_h
+          @definitions.reduce({}) do |shape_hash, (key, value)|
+            shape_hash.merge(key => value.to_h)
+          end
+        end
+
+        private
+
+        def string(context_key, formatter: nil)
+          dedup(context_key, :string)
+          @definitions[context_key] = RegistryTypes::String.new(formatter: formatter)
+        end
+
+        def boolean(context_key, formatter: nil)
+          dedup(context_key, :boolean)
+          @definitions[context_key] = RegistryTypes::Boolean.new(formatter: formatter)
+        end
+
+        def number(context_key, formatter: nil)
+          dedup(context_key, :number)
+          @definitions[context_key] = RegistryTypes::Number.new(formatter: formatter)
+        end
+
+        def date(context_key, formatter: nil)
+          dedup(context_key, :date)
+          @definitions[context_key] = RegistryTypes::Date.new(formatter: formatter)
+        end
+
+        def hash(context_key, &definitions)
+          dedup(context_key, :hash)
+          @definitions[context_key] = RegistryTypes::Hash.new(&definitions)
+        end
+
+        def run(&definitions)
+          instance_eval(&definitions)
+        end
+
+        def dedup(key, type)
+          @definitions.include?(key) and
+            raise Registry::DuplicateDefinitionError, "Defining duplicate entry #{key} previously as #{@definitions[key]} and now as #{type}"
+        end
+      end
+    end
+  end
+end

--- a/lib/contextual_logger/context/registry_types/number.rb
+++ b/lib/contextual_logger/context/registry_types/number.rb
@@ -13,6 +13,15 @@ module ContextualLogger
         def to_h
           { type: :number, formatter: formatter }
         end
+
+        def format(value)
+          case formatter
+          when Proc
+            formatter.call(value)
+          else
+            value.send(formatter)
+          end
+        end
       end
     end
   end

--- a/lib/contextual_logger/context/registry_types/number.rb
+++ b/lib/contextual_logger/context/registry_types/number.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ContextualLogger
+  module Context
+    module RegistryTypes
+      class Number
+        attr_reader :formatter
+
+        def initialize(formatter: nil)
+          @formatter = formatter || :to_i
+        end
+
+        def to_h
+          { type: :number, formatter: formatter }
+        end
+      end
+    end
+  end
+end

--- a/lib/contextual_logger/context/registry_types/string.rb
+++ b/lib/contextual_logger/context/registry_types/string.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ContextualLogger
+  module Context
+    module RegistryTypes
+      class String
+        attr_reader :formatter
+
+        def initialize(formatter: nil)
+          @formatter = formatter || :to_s
+        end
+
+        def to_h
+          { type: :string, formatter: formatter }
+        end
+      end
+    end
+  end
+end

--- a/lib/contextual_logger/context/registry_types/string.rb
+++ b/lib/contextual_logger/context/registry_types/string.rb
@@ -13,6 +13,15 @@ module ContextualLogger
         def to_h
           { type: :string, formatter: formatter }
         end
+
+        def format(value)
+          case formatter
+          when Proc
+            formatter.call(value)
+          else
+            value.send(formatter)
+          end
+        end
       end
     end
   end

--- a/lib/contextual_logger/version.rb
+++ b/lib/contextual_logger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContextualLogger
-  VERSION = '0.11.0'
+  VERSION = '0.12.0.pre.1'
 end

--- a/spec/lib/contextual_logger/context/registry_spec.rb
+++ b/spec/lib/contextual_logger/context/registry_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'contextual_logger'
+
+def itShouldDedupRegistry(&block)
+  context 'when defining duplicate keys' do
+    it 'raises a DuplicateDefinitionError' do
+      expect { described_class.new(&block) }.to raise_error(ContextualLogger::Context::Registry::DuplicateDefinitionError)
+    end
+  end
+end
+
+RSpec.describe ContextualLogger::Context::Registry do
+  let(:registry) { described_class.new {} }
+
+  context '#strict?' do
+    subject { registry.strict? }
+
+    context 'when defined with an empty block' do
+      it { should be_truthy }
+    end
+
+    context 'when defined in the registry configuration as true' do
+      let(:registry) { described_class.new { strict true } }
+      it { should be_truthy }
+    end
+
+    context 'when defined in the registry configuration as false' do
+      let(:registry) { described_class.new { strict false } }
+      it { should be_falsey }
+    end
+  end
+
+  context '#context_shape_hash' do
+    let(:expected_context_shape) { {} }
+    subject { registry.context_shape_hash }
+
+    context 'when defined with an empty block' do
+      it { should be_empty }
+    end
+
+    context 'when defining strings' do
+      context 'when defining a context entry' do
+        let(:registry) do
+          described_class.new do
+            string :test_context
+          end
+        end
+
+        let(:expected_context_shape) do
+          { test_context: { type: :string, formatter: :to_s } }
+        end
+
+        it { should eq(expected_context_shape)}
+      end
+
+      itShouldDedupRegistry do
+        string :test_context
+        string :test_context
+      end
+    end
+
+    context 'when defining booleans' do
+      context 'when defining a context entry' do
+        let(:registry) do
+          described_class.new do
+            boolean :test_context
+          end
+        end
+
+        let(:expected_context_shape) do
+          { test_context: hash_including({ type: :boolean }) }
+        end
+
+        it { should include(expected_context_shape)}
+      end
+
+      itShouldDedupRegistry do
+        boolean :test_context
+        boolean :test_context
+      end
+    end
+
+    context 'when defining numbers' do
+      context 'when defining a context entry' do
+        let(:registry) do
+          described_class.new do
+            number :test_context
+          end
+        end
+
+        let(:expected_context_shape) do
+          { test_context: { type: :number, formatter: :to_i } }
+        end
+
+        it { should eq(expected_context_shape)}
+      end
+
+      itShouldDedupRegistry do
+        number :test_context
+        number :test_context
+      end
+    end
+
+    context 'when defining dates' do
+      context 'when defining a context entry' do
+        let(:registry) do
+          described_class.new do
+            date :test_context
+          end
+        end
+
+        let(:expected_context_shape) do
+          { test_context: hash_including({ type: :date }) }
+        end
+
+        it { should include(expected_context_shape)}
+      end
+
+      itShouldDedupRegistry do
+        date :test_context
+        date :test_context
+      end
+    end
+  end
+end

--- a/spec/lib/contextual_logger/context/registry_spec.rb
+++ b/spec/lib/contextual_logger/context/registry_spec.rb
@@ -31,6 +31,24 @@ RSpec.describe ContextualLogger::Context::Registry do
     end
   end
 
+  context '#raise_on_missing_definition?' do
+    subject { registry.raise_on_missing_definition? }
+
+    context 'when defined with an empty block' do
+      it { should be_truthy }
+    end
+
+    context 'when defined in the registry configuration as true' do
+      let(:registry) { described_class.new { raise_on_missing_definition true } }
+      it { should be_truthy }
+    end
+
+    context 'when defined in the registry configuration as false' do
+      let(:registry) { described_class.new { raise_on_missing_definition false } }
+      it { should be_falsey }
+    end
+  end
+
   context '#context_shape' do
     let(:expected_context_shape) { {} }
     subject { registry.context_shape }

--- a/spec/lib/contextual_logger/context/registry_spec.rb
+++ b/spec/lib/contextual_logger/context/registry_spec.rb
@@ -2,7 +2,7 @@
 
 require 'contextual_logger'
 
-def itShouldDedupRegistry(&block)
+def it_should_dedup_registry(&block)
   context 'when defining duplicate keys' do
     it 'raises a DuplicateDefinitionError' do
       expect { described_class.new(&block) }.to raise_error(ContextualLogger::Context::Registry::DuplicateDefinitionError)
@@ -11,7 +11,7 @@ def itShouldDedupRegistry(&block)
 end
 
 RSpec.describe ContextualLogger::Context::Registry do
-  let(:registry) { described_class.new {} }
+  let(:registry) { described_class.new { } }
 
   context '#strict?' do
     subject { registry.strict? }
@@ -69,10 +69,10 @@ RSpec.describe ContextualLogger::Context::Registry do
           { test_context: { type: :string, formatter: :to_s } }
         end
 
-        it { should eq(expected_context_shape)}
+        it { should eq(expected_context_shape) }
       end
 
-      itShouldDedupRegistry do
+      it_should_dedup_registry do
         string :test_context
         string :test_context
       end
@@ -90,10 +90,10 @@ RSpec.describe ContextualLogger::Context::Registry do
           { test_context: hash_including({ type: :boolean }) }
         end
 
-        it { should include(expected_context_shape)}
+        it { should include(expected_context_shape) }
       end
 
-      itShouldDedupRegistry do
+      it_should_dedup_registry do
         boolean :test_context
         boolean :test_context
       end
@@ -111,10 +111,10 @@ RSpec.describe ContextualLogger::Context::Registry do
           { test_context: { type: :number, formatter: :to_i } }
         end
 
-        it { should eq(expected_context_shape)}
+        it { should eq(expected_context_shape) }
       end
 
-      itShouldDedupRegistry do
+      it_should_dedup_registry do
         number :test_context
         number :test_context
       end
@@ -132,17 +132,17 @@ RSpec.describe ContextualLogger::Context::Registry do
           { test_context: hash_including({ type: :date }) }
         end
 
-        it { should include(expected_context_shape)}
+        it { should include(expected_context_shape) }
       end
 
-      itShouldDedupRegistry do
+      it_should_dedup_registry do
         date :test_context
         date :test_context
       end
     end
 
     context 'when defining a hash' do
-      itShouldDedupRegistry do
+      it_should_dedup_registry do
         hash :test_context do
           string :test_sub_context
         end
@@ -172,7 +172,7 @@ RSpec.describe ContextualLogger::Context::Registry do
           }
         end
 
-        it { should eq(expected_context_shape)}
+        it { should eq(expected_context_shape) }
       end
 
       context 'when defining nested context entries' do
@@ -204,7 +204,7 @@ RSpec.describe ContextualLogger::Context::Registry do
           }
         end
 
-        it { should eq(expected_context_shape)}
+        it { should eq(expected_context_shape) }
       end
     end
   end

--- a/spec/lib/contextual_logger/context/registry_spec.rb
+++ b/spec/lib/contextual_logger/context/registry_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe ContextualLogger::Context::Registry do
     end
   end
 
-  context '#context_shape_hash' do
+  context '#context_shape' do
     let(:expected_context_shape) { {} }
-    subject { registry.context_shape_hash }
+    subject { registry.context_shape }
 
     context 'when defined with an empty block' do
       it { should be_empty }
@@ -120,6 +120,73 @@ RSpec.describe ContextualLogger::Context::Registry do
       itShouldDedupRegistry do
         date :test_context
         date :test_context
+      end
+    end
+
+    context 'when defining a hash' do
+      itShouldDedupRegistry do
+        hash :test_context do
+          string :test_sub_context
+        end
+
+        hash :test_context do
+          string :test_sub_context
+        end
+      end
+
+      context 'when defining a context entry' do
+        let(:registry) do
+          described_class.new do
+            hash :test_context do
+              string :test_sub_context
+            end
+          end
+        end
+
+        let(:expected_context_shape) do
+          {
+            test_context: {
+              test_sub_context: {
+                type: :string,
+                formatter: :to_s
+              }
+            }
+          }
+        end
+
+        it { should eq(expected_context_shape)}
+      end
+
+      context 'when defining nested context entries' do
+        let(:registry) do
+          described_class.new do
+            hash :test_context do
+              string :test_sub_context
+              hash :test_sub_context_hash do
+                number :test_sub_context_number
+              end
+            end
+          end
+        end
+
+        let(:expected_context_shape) do
+          {
+            test_context: {
+              test_sub_context: {
+                type: :string,
+                formatter: :to_s
+              },
+              test_sub_context_hash: {
+                test_sub_context_number: {
+                  type: :number,
+                  formatter: :to_i
+                }
+              }
+            }
+          }
+        end
+
+        it { should eq(expected_context_shape)}
       end
     end
   end

--- a/spec/lib/contextual_logger/logger_with_context_spec.rb
+++ b/spec/lib/contextual_logger/logger_with_context_spec.rb
@@ -101,7 +101,11 @@ describe ContextualLogger::LoggerWithContext do
 
     context "when string passed as context key" do
       before do
-        expect(ActiveSupport::Deprecation).to receive(:warn).with('Context keys must use symbols not strings. This will be asserted as of contextual_logger v1.0.0').and_return(true)
+        expect(ActiveSupport::Deprecation).to(
+          receive(:warn)
+            .with('Context keys must use symbols not strings. This will be asserted as of contextual_logger v1.0.0')
+            .and_return(true)
+        )
       end
 
       it "returns context with a symbol key" do

--- a/spec/lib/contextual_logger/logger_with_context_spec.rb
+++ b/spec/lib/contextual_logger/logger_with_context_spec.rb
@@ -100,6 +100,10 @@ describe ContextualLogger::LoggerWithContext do
     end
 
     context "when string passed as context key" do
+      before do
+        expect(ActiveSupport::Deprecation).to receive(:warn).with('Context keys must use symbols not strings. This will be asserted as of contextual_logger v1.0.0').and_return(true)
+      end
+
       it "returns context with a symbol key" do
         context_with_string_key = { "log_source" => "redis_client" }
         string_context = ContextualLogger::LoggerWithContext.new(base_logger, context_with_string_key)
@@ -111,12 +115,6 @@ describe ContextualLogger::LoggerWithContext do
         string_context = ContextualLogger::LoggerWithContext.new(base_logger, context_with_string_key_levels)
         expect(string_context.context)
           .to eq({ log_source: { level1: { level2: { level3: "redis_client" } } } })
-      end
-
-      it "should return a deprecation warning" do
-        context_with_string_key = { "log_source" => "redis_client" }
-        expect { ContextualLogger::LoggerWithContext.new(base_logger, context_with_string_key) }
-          .to output(/DEPRECATION WARNING: Context keys must use symbols not strings/).to_stderr
       end
     end
 

--- a/spec/lib/contextual_logger_spec.rb
+++ b/spec/lib/contextual_logger_spec.rb
@@ -26,10 +26,10 @@ describe ContextualLogger do
 
   it { is_expected.to respond_to(:with_context) }
 
-  context '#configure_context' do
+  context '#register_context' do
     context 'when a block is not given' do
       it 'raises an ArgumentError' do
-        expect { logger.configure_context }.to raise_error(ArgumentError, 'Block of context definitions was not passed')
+        expect { logger.register_context }.to raise_error(ArgumentError, 'Block of context definitions was not passed')
       end
     end
   end

--- a/spec/lib/contextual_logger_spec.rb
+++ b/spec/lib/contextual_logger_spec.rb
@@ -26,6 +26,14 @@ describe ContextualLogger do
 
   it { is_expected.to respond_to(:with_context) }
 
+  context '#configure_context' do
+    context 'when a block is not given' do
+      it 'raises an ArgumentError' do
+        expect { logger.configure_context }.to raise_error(ArgumentError, 'Block of context definitions was not passed')
+      end
+    end
+  end
+
   context 'with logger writing to log_stream' do
     let(:log_stream) { StringIO.new }
     let(:log_level) { Logger::Severity::DEBUG }

--- a/spec/lib/contextual_logger_spec.rb
+++ b/spec/lib/contextual_logger_spec.rb
@@ -273,10 +273,11 @@ describe ContextualLogger do
       end
     end
 
-    context 'when a context registry has been applied in strict mode' do
+    context 'when a context registry has been applied in strict mode and raise_on_missing_definition disabled' do
       before do
         logger.register_context do
           strict true
+          raise_on_missing_definition false
 
           string :service
           string :file
@@ -293,7 +294,7 @@ describe ContextualLogger do
 
       subject { logger.info('this is a test', **log_context) }
 
-      context 'when inline context is applying only registered context' do
+      context 'when applying only registered context' do
         let(:log_context) do
           { service: 'test_service' }
         end
@@ -310,7 +311,7 @@ describe ContextualLogger do
         it { should be_truthy }
       end
 
-      context 'when inline context is applying non registered context' do
+      context 'when applying non registered context' do
         let(:log_context) do
           { service: 'test_service', non_registered: 'test_service' }
         end
@@ -327,7 +328,7 @@ describe ContextualLogger do
         it { should be_truthy }
       end
 
-      context 'when inline context is applying nested registered content' do
+      context 'when applying nested registered content' do
         let(:log_context) do
           {
             service: 'test_service',
@@ -356,6 +357,73 @@ describe ContextualLogger do
         end
 
         it { should be_truthy }
+      end
+    end
+
+    context 'when a context registry has been applied in strict mode and raise_on_missing_definition enabled' do
+      before do
+        logger.register_context do
+          strict true
+          raise_on_missing_definition true
+
+          string :service
+          string :file
+
+          hash :kubernetes do
+            string :context
+            string :namespace
+            number :port
+          end
+        end
+      end
+
+      subject { logger.info('this is a test', **log_context) }
+
+      context 'when applying only registered context' do
+        let(:log_context) do
+          { service: 'test_service' }
+        end
+
+        let(:expected_log_hash) do
+          {
+            service: 'test_service',
+            message: 'this is a test',
+            timestamp: Time.now,
+            severity: "INFO"
+          }
+        end
+
+        before { expect_log_line_to_be_written(expected_log_hash.to_json) }
+
+        it { should be_truthy }
+      end
+
+      context 'when applying non registered context' do
+        let(:log_context) do
+          { service: 'test_service', non_registered: 'test_service' }
+        end
+
+        it 'raises a MissingDefinitionError' do
+          expect { subject }.to raise_error(ContextualLogger::Context::Registry::MissingDefinitionError)
+        end
+      end
+
+      context 'when applying nested registered content' do
+        let(:log_context) do
+          {
+            service: 'test_service',
+            kubernetes: {
+              context: 'hello',
+              namespace: 'world',
+              port: '1232',
+              kubernetes_non_registered: 'filter_me_out'
+            }
+          }
+        end
+
+        it 'raises a MissingDefinitionError' do
+          expect { subject }.to raise_error(ContextualLogger::Context::Registry::MissingDefinitionError)
+        end
       end
     end
   end
@@ -456,10 +524,11 @@ describe ContextualLogger do
       handler1.reset!
     end
 
-    context 'when a context registry has been applied in strict mode' do
+    context 'when a context registry has been applied in strict mode and raise_on_missing_definition is disabled' do
       before do
         logger.register_context do
           strict true
+          raise_on_missing_definition false
 
           string :service
           string :file
@@ -477,7 +546,7 @@ describe ContextualLogger do
       context 'logger#current_context_for_thread' do
         subject { logger.current_context_for_thread }
 
-        context 'when global context is applying only registered context' do
+        context 'when applying only registered context' do
           let(:log_context) do
             { service: 'test_service' }
           end
@@ -489,7 +558,7 @@ describe ContextualLogger do
           it { should eq(expected_current_context) }
         end
 
-        context 'when global context is applying non registered context' do
+        context 'when applying non registered context' do
           let(:log_context) do
             { service: 'test_service', non_registered: 'test_service' }
           end
@@ -501,7 +570,7 @@ describe ContextualLogger do
           it { should eq(expected_current_context) }
         end
 
-        context 'when global context is applying nested registered content' do
+        context 'when applying nested registered content' do
           let(:log_context) do
             {
               service: 'test_service',
@@ -527,6 +596,62 @@ describe ContextualLogger do
           end
 
           it { should eq(expected_current_context) }
+        end
+      end
+    end
+
+    context 'when a context registry has been applied in strict mode and raise_on_missing_definition is enabled' do
+      before do
+        logger.register_context do
+          strict true
+          raise_on_missing_definition true
+
+          string :service
+          string :file
+
+          hash :kubernetes do
+            string :context
+            string :namespace
+            number :port
+          end
+        end
+      end
+
+      subject { logger.with_context(log_context) }
+
+      context 'when applying only registered context' do
+        let(:log_context) do
+          { service: 'test_service' }
+        end
+
+        it { should be_truthy }
+      end
+
+      context 'when applying non registered context' do
+        let(:log_context) do
+          { service: 'test_service', non_registered: 'test_service' }
+        end
+
+        it 'raises a MissingDefinitionError' do
+          expect { subject }.to raise_error(ContextualLogger::Context::Registry::MissingDefinitionError)
+        end
+      end
+
+      context 'when applying nested registered content' do
+        let(:log_context) do
+          {
+            service: 'test_service',
+            kubernetes: {
+              context: 'hello',
+              namespace: 'world',
+              port: '1232',
+              kubernetes_non_registered: 'filter_me_out'
+            }
+          }
+        end
+
+        it 'raises a MissingDefinitionError' do
+          expect { subject }.to raise_error(ContextualLogger::Context::Registry::MissingDefinitionError)
         end
       end
     end
@@ -563,10 +688,11 @@ describe ContextualLogger do
       end
     end
 
-    context 'when a context registry has been applied in strict mode' do
+    context 'when a context registry has been applied in strict mode and raise_on_missing_definition is disabled' do
       before do
         logger.register_context do
           strict true
+          raise_on_missing_definition false
 
           string :service
           string :file
@@ -584,7 +710,7 @@ describe ContextualLogger do
       context 'logger#current_context_for_thread' do
         subject { logger.current_context_for_thread }
 
-        context 'when global context is applying only registered context' do
+        context 'when applying only registered context' do
           let(:global_context) do
             { service: 'test_service' }
           end
@@ -596,7 +722,7 @@ describe ContextualLogger do
           it { should eq(expected_current_context) }
         end
 
-        context 'when global context is applying non registered context' do
+        context 'when applying non registered context' do
           let(:global_context) do
             { service: 'test_service', non_registered: 'test_service' }
           end
@@ -608,7 +734,7 @@ describe ContextualLogger do
           it { should eq(expected_current_context) }
         end
 
-        context 'when global context is applying nested registered content' do
+        context 'when applying nested registered content' do
           let(:global_context) do
             {
               service: 'test_service',
@@ -634,6 +760,62 @@ describe ContextualLogger do
           end
 
           it { should eq(expected_current_context) }
+        end
+      end
+    end
+
+    context 'when a context registry has been applied in strict mode and raise_on_missing_definition is enabled' do
+      before do
+        logger.register_context do
+          strict true
+          raise_on_missing_definition true
+
+          string :service
+          string :file
+
+          hash :kubernetes do
+            string :context
+            string :namespace
+            number :port
+          end
+        end
+      end
+
+      subject { logger.global_context = global_context }
+
+      context 'when applying only registered context' do
+        let(:global_context) do
+          { service: 'test_service' }
+        end
+
+        it { should be_truthy }
+      end
+
+      context 'when applying non registered context' do
+        let(:global_context) do
+          { service: 'test_service', non_registered: 'test_service' }
+        end
+
+        it 'raises a MissingDefinitionError' do
+          expect { subject }.to raise_error(ContextualLogger::Context::Registry::MissingDefinitionError)
+        end
+      end
+
+      context 'when applying nested registered content' do
+        let(:global_context) do
+          {
+            service: 'test_service',
+            kubernetes: {
+              context: 'hello',
+              namespace: 'world',
+              port: '1232',
+              kubernetes_non_registered: 'filter_me_out'
+            }
+          }
+        end
+
+        it 'raises a MissingDefinitionError' do
+          expect { subject }.to raise_error(ContextualLogger::Context::Registry::MissingDefinitionError)
         end
       end
     end

--- a/spec/lib/contextual_logger_spec.rb
+++ b/spec/lib/contextual_logger_spec.rb
@@ -237,40 +237,40 @@ describe ContextualLogger do
         end
       end
     end
-  end
 
-  describe 'inline context' do
-    let(:expected_log_hash) do
-      {
-        service: 'test_service',
-        message: 'this is a test',
-        timestamp: Time.now
-      }
-    end
+    context "with different log levels" do
+      let(:expected_log_hash) do
+        {
+          service: 'test_service',
+          message: 'this is a test',
+          timestamp: Time.now
+        }
+      end
 
-    it 'prints out context passed into debug' do
-      expect_log_line_to_be_written(expected_log_hash.merge(severity: 'DEBUG').to_json)
-      expect(logger.debug('this is a test', service: 'test_service')).to eq(true)
-    end
+      it 'prints out context passed into debug' do
+        expect_log_line_to_be_written(expected_log_hash.merge(severity: 'DEBUG').to_json)
+        expect(logger.debug('this is a test', service: 'test_service')).to eq(true)
+      end
 
-    it 'prints out context passed into info' do
-      expect_log_line_to_be_written(expected_log_hash.merge(severity: 'INFO').to_json)
-      expect(logger.info('this is a test', service: 'test_service')).to eq(true)
-    end
+      it 'prints out context passed into info' do
+        expect_log_line_to_be_written(expected_log_hash.merge(severity: 'INFO').to_json)
+        expect(logger.info('this is a test', service: 'test_service')).to eq(true)
+      end
 
-    it 'prints out context passed into warn' do
-      expect_log_line_to_be_written(expected_log_hash.merge(severity: 'WARN').to_json)
-      expect(logger.warn('this is a test', service: 'test_service')).to eq(true)
-    end
+      it 'prints out context passed into warn' do
+        expect_log_line_to_be_written(expected_log_hash.merge(severity: 'WARN').to_json)
+        expect(logger.warn('this is a test', service: 'test_service')).to eq(true)
+      end
 
-    it 'prints out context passed into error' do
-      expect_log_line_to_be_written(expected_log_hash.merge(severity: 'ERROR').to_json)
-      expect(logger.error('this is a test', service: 'test_service')).to eq(true)
-    end
+      it 'prints out context passed into error' do
+        expect_log_line_to_be_written(expected_log_hash.merge(severity: 'ERROR').to_json)
+        expect(logger.error('this is a test', service: 'test_service')).to eq(true)
+      end
 
-    it 'prints out context passed into fatal' do
-      expect_log_line_to_be_written(expected_log_hash.merge(severity: 'FATAL').to_json)
-      expect(logger.fatal('this is a test', service: 'test_service')).to eq(true)
+      it 'prints out context passed into fatal' do
+        expect_log_line_to_be_written(expected_log_hash.merge(severity: 'FATAL').to_json)
+        expect(logger.fatal('this is a test', service: 'test_service')).to eq(true)
+      end
     end
   end
 

--- a/spec/lib/contextual_logger_spec.rb
+++ b/spec/lib/contextual_logger_spec.rb
@@ -369,6 +369,81 @@ describe ContextualLogger do
       expect(logger.info('this is a test')).to eq(true)
       handler1.reset!
     end
+
+    context 'when a context registry has been applied in strict mode' do
+      before do
+        logger.register_context do
+          strict true
+
+          string :service
+          string :file
+
+          hash :kubernetes do
+            string :context
+            string :namespace
+            number :port
+          end
+        end
+
+        logger.with_context(log_context)
+      end
+
+      context 'logger#current_context_for_thread' do
+        subject { logger.current_context_for_thread }
+
+        context 'when global context is applying only registered context' do
+          let(:log_context) do
+            { service: 'test_service' }
+          end
+
+          let(:expected_current_context) do
+            { service: 'test_service' }
+          end
+
+          it { should eq(expected_current_context) }
+        end
+
+        context 'when global context is applying non registered context' do
+          let(:log_context) do
+            { service: 'test_service', non_registered: 'test_service' }
+          end
+
+          let(:expected_current_context) do
+            { service: 'test_service' }
+          end
+
+          it { should eq(expected_current_context) }
+        end
+
+        context 'when global context is applying nested registered content' do
+          let(:log_context) do
+            {
+              service: 'test_service',
+              non_registered: 'filter_me_out',
+              kubernetes: {
+                context: 'hello',
+                namespace: 'world',
+                port: '1232',
+                kubernetes_non_registered: 'filter_me_out'
+              }
+            }
+          end
+
+          let(:expected_current_context) do
+            {
+              service: 'test_service',
+              kubernetes: {
+                context: 'hello',
+                namespace: 'world',
+                port: 1232
+              }
+            }
+          end
+
+          it { should eq(expected_current_context) }
+        end
+      end
+    end
   end
 
   describe 'global_context' do


### PR DESCRIPTION
## 0.12.0
### Added
- Added a new interface for defining the expected structure of the logger's context
- Added the ability to strictly enforce the structure of the logger's context by
removing all undefined context keys
- Added the ability to raise when attempting to apply context with undefined keys

## Strictly Defining Context

The introduction of dynamic context in logging introduces a couple new problems that
need to be solved. First the strict definition of a structure for the logs so that
unknown bloat is removed, and second the strict definition of data types so that when
the data arrives at the end data store it arrives in the right format for injestion.

This is why this gem has the ability to strictly define the context that is expected by
registering the schema of the logger.

### Basic Example

In this basic example, we are configuring the logger to:

1. Strictly manage the context based on the definitions present
2. **Not** raise exceptions when missing definitions are encountered
3. Expect a basic log context to be applied contining:
    1. A `service_name` string
    2. A `kubernetes` hash containing:
        1. A `namespace` string
        2. A `context` string
        3. A `pod_name` string
  3. A `user` hash containing:
      1. A numerical `id`
      2. An `email` string
      3. A `created_at` date object

```ruby
contextual_logger.register_context do
  # This makes it so that the logger will enforce the shape and formating
  # defined within the Context::Registry, stripping out any context keys
  # that are not defined in the registry, and enforcing formatting rules
  # on all values
  strict true
  # This makes it so that the logger will not raise a MissingDefinitionError
  # when code tries to apply a context key that does not map to a definition
  # in the registry
  raise_on_missing_definition false
  string :service_name
  hash :kubernetes do
    string :namespace
    string :context
    string :pod_name
  end
  hash :user do
    number :id
    string :email
    date   :created_at
  end
end
```

### Production Best Practices

In `production` environments it is best to protect your logging from excess bloat by
setting `strict` to `true`, and `raise_on_missing_definition` to `false` in order
to protect against logging causing unnecessary errors.

```ruby
contextual_logger.register_context do
  strict true
  raise_on_missing_definition false
end
```

### Test and Development Best Practices

When running in `test` and `development` environments it is best to be quickly aware
that context is being erroniously added to the logs by setting both `strict` and
`raise_on_missing_definition` to `true`.

```ruby
contextual_logger.register_context do
  strict true
  raise_on_missing_definition true
end
```

### Available Configurations

| Config | Description | Default |
| ------ | :---------: | ------: |
| `strict` | When enabled the logger will enforce the shape of the context specified by dropping context keys that are not definied and running formatters across the data | `true` |
| `raise_on_missing_definition` | When enabled, the logger will raise and exception if a context key is added to the logger that does not have a definition defined | `true` |

### Available Definitions

| Config    | Description | Default Format |
| --------- | :---------: | :-----: |
| `string`  | The provided key will be formatted and enforced as a String | `:to_s` |
| `number`  | The provided key will be formatted and enforced as a numeric value | `:to_i` |
| `boolean` | The provided key will be formatted and enforced as a boolean value | `->(value) { value ? true : false }` |
| `date`    | The provided key will be formatted and enforced as a date string | `->(value) { value.iso8601(6) }` |
| `hash`    | The provided key will be formatted and enforced as a hash | |