### PR TITLE
Tech 9529 update register regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2022-11-29
+### Added
+- Bug fix for registering regex
+- Added specs around registering regex delegation
+- renamed function registering_regex to registering_secret_regex
+
 ## [1.1.0] - 2022-11-29
 ### Added
 - Added support for registering regex for secret redaction

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    contextual_logger (1.1.0)
+    contextual_logger (1.1.1.pre.bll.0)
       activesupport
       json
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    contextual_logger (1.1.1.pre.bll.0)
+    contextual_logger (1.1.1)
       activesupport
       json
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The above will produce the resulting log line:
 Regex is also supported for redaction:
 ```ruby
 regex = /(key|password|token|secret)[_a-z]*[\s\"]*(:|=>|=)[\s\"]*\K([0-9a-z_]*)/i
-contextual_logger.register_regex(regex)
+contextual_logger.register_secret_regex(regex)
 
 contextual_logger.info("Request set with body { 'username': 'test_user', 'password': 'ffbba9b905c0a549b48f48894ad7aa9b7bd7c06c' } }")
 ```

--- a/lib/contextual_logger.rb
+++ b/lib/contextual_logger.rb
@@ -43,7 +43,7 @@ module ContextualLogger
   end
 
   module LoggerMixin
-    delegate :register_secret, to: :redactor
+    delegate :register_secret, :register_secret_regex, to: :redactor
 
     def global_context=(context)
       Context::Handler.new(context).set!

--- a/lib/contextual_logger/redactor.rb
+++ b/lib/contextual_logger/redactor.rb
@@ -10,10 +10,10 @@ module ContextualLogger
     end
 
     def register_secret(sensitive_data)
-      register_regex(Regexp.escape(sensitive_data))
+      register_secret_regex(Regexp.escape(sensitive_data))
     end
 
-    def register_regex(regex)
+    def register_secret_regex(regex)
       if redaction_set.add?(regex)
         @redaction_regex = Regexp.new(
           redaction_set.to_a.join('|')

--- a/lib/contextual_logger/version.rb
+++ b/lib/contextual_logger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContextualLogger
-  VERSION = '1.1.1.pre.bll.0'
+  VERSION = '1.1.1'
 end

--- a/lib/contextual_logger/version.rb
+++ b/lib/contextual_logger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContextualLogger
-  VERSION = '1.1.0'
+  VERSION = '1.1.1.pre.bll.0'
 end

--- a/spec/lib/contextual_logger/redactor_spec.rb
+++ b/spec/lib/contextual_logger/redactor_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ContextualLogger::Redactor do
 
   describe '#redact' do
     before(:each) do
-      subject.register_regex('(key|password|token|secret)[_a-z]*[\s\"]*(:|=>|=)[\s\"]*\K([0-9a-z_]*)')
+      subject.register_secret_regex('(key|password|token|secret)[_a-z]*[\s\"]*(:|=>|=)[\s\"]*\K([0-9a-zA-Z_]*)')
       subject.register_secret('hello')
     end
 

--- a/spec/lib/contextual_logger_spec.rb
+++ b/spec/lib/contextual_logger_spec.rb
@@ -542,6 +542,7 @@ describe ContextualLogger do
 
     before(:each) do
       logger.register_secret(sensitive_data)
+      logger.register_secret_regex('(key|password|token|secret)[_a-z]*[\s\"]*(:|=>|=)[\s\"]*\K([0-9a-zA-Z_]*)')
     end
 
     describe 'with sensitive data in the message' do
@@ -557,6 +558,12 @@ describe ContextualLogger do
       it 'replaces sensitive data with <redacted>' do
         expect_log_line_to_be_written(expected_log_hash.to_json)
         expect(logger.debug("this is a test with #{sensitive_data}", service: 'test_service')).to eq(true)
+      end
+
+      it 'replaces matching patterns in the data with <redacted>' do
+        expected_log_hash[:message] = 'this is a test token=<redacted>'
+        expect_log_line_to_be_written(expected_log_hash.to_json)
+        expect(logger.debug("this is a test token=aAbBcC1_2DdEeFf", service: 'test_service')).to eq(true)
       end
     end
 


### PR DESCRIPTION
## Add Delegate and Spec to renamed Register Regex method
* __Issue Link:__ TECH-9529 <!-- Use [magic GitHub words](https://help.github.com/articles/closing-issues-using-keywords/) to link to the issue here -->

### Summary of Changes
- renamed register_regex to register_secret_regex
- added delegate for register_secret_regex in the logger
- added spec to test delegation
